### PR TITLE
Fix Broken Logos on Package Pages

### DIFF
--- a/.cursor/commands/bump.md
+++ b/.cursor/commands/bump.md
@@ -1,0 +1,6 @@
+- Bump the version in `gleam.toml` 
+- Bump the version in all applicable `modules/<module_name>/gleam.toml` files if there are any changes to the module
+- Update the `CHANGELOG.md`
+- Update the `README.md`
+- Create a new release in `releases/release-<version>.md`
+- Update any other references to latest versions in the documentation and codebase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-11-22
+
+### Fixed
+- Fixed logo display on hex.pm by using full GitHub URLs instead of relative paths in README files
+- Added Dream logo to all module README files (dream_config, dream_ets, dream_http_client, dream_json, dream_opensearch, dream_postgres)
+
 ## [1.0.0] - 2025-11-21
 
 ### Added
@@ -66,7 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All code examples now include proper imports
 - Improved documentation tone and consistency
 
-[Unreleased]: https://github.com/TrustBound/dream/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/TrustBound/dream/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/TrustBound/dream/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/TrustBound/dream/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/TrustBound/dream/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/TrustBound/dream/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="ricky_and_lucy.png" alt="Dream Logo" width="200" alt="Ricky Moony and Lucy, a moon shaped mascot for Dream with the star shaped mascot for Gleam, each with cute cartoon eyes and a smile">
+  <img src="https://raw.githubusercontent.com/TrustBound/dream/main/ricky_and_lucy.png" alt="Dream Logo" width="200" alt="Ricky Moony and Lucy, a moon shaped mascot for Dream with the star shaped mascot for Gleam, each with cute cartoon eyes and a smile">
 
   <b>Clean, composable web development for Gleam. No magic.</b>
 </div>

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream"
-version = "1.0.0"
+version = "1.0.1"
 description = "A composable web library for Gleam/BEAM"
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }

--- a/modules/config/CHANGELOG.md
+++ b/modules/config/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `dream_config` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1 - 2025-11-22
+
+### Fixed
+- Fixed logo display on hex.pm by using full GitHub URL
+- Added Dream logo to README
+
 ## 1.0.0 - 2025-11-21
 
 ### Added

--- a/modules/config/README.md
+++ b/modules/config/README.md
@@ -1,3 +1,7 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/TrustBound/dream/main/ricky_and_lucy.png" alt="Dream Logo" width="200">
+</div>
+
 # dream_config
 
 **Type-safe configuration management for Gleam applications.**

--- a/modules/config/gleam.toml
+++ b/modules/config/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream_config"
-version = "1.0.0"
+version = "1.0.1"
 description = "Type-safe configuration management for Gleam applications"
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }

--- a/modules/ets/CHANGELOG.md
+++ b/modules/ets/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `dream_ets` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1 - 2025-11-22
+
+### Fixed
+- Fixed logo display on hex.pm by using full GitHub URL
+- Added Dream logo to README
+
 ## 1.0.0 - 2025-11-21
 
 ### Added

--- a/modules/ets/README.md
+++ b/modules/ets/README.md
@@ -1,3 +1,7 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/TrustBound/dream/main/ricky_and_lucy.png" alt="Dream Logo" width="200">
+</div>
+
 # dream_ets
 
 **Type-safe ETS (Erlang Term Storage) for Gleam.**

--- a/modules/ets/gleam.toml
+++ b/modules/ets/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream_ets"
-version = "1.0.0"
+version = "1.0.1"
 description = "Type-safe ETS (Erlang Term Storage) for Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }

--- a/modules/http_client/CHANGELOG.md
+++ b/modules/http_client/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `dream_http_client` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1 - 2025-11-22
+
+### Fixed
+- Fixed logo display on hex.pm by using full GitHub URL
+- Added Dream logo to README
+
 ## 1.0.0 - 2025-11-21
 
 ### Added

--- a/modules/http_client/README.md
+++ b/modules/http_client/README.md
@@ -1,3 +1,7 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/TrustBound/dream/main/ricky_and_lucy.png" alt="Dream Logo" width="200">
+</div>
+
 # dream_http_client
 
 **Type-safe HTTP client for Gleam with streaming support.**

--- a/modules/http_client/gleam.toml
+++ b/modules/http_client/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream_http_client"
-version = "1.0.0"
+version = "1.0.1"
 description = "Type-safe HTTP client for Gleam with streaming support"
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }

--- a/modules/json/CHANGELOG.md
+++ b/modules/json/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `dream_json` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1 - 2025-11-22
+
+### Fixed
+- Fixed logo display on hex.pm by using full GitHub URL
+- Added Dream logo to README
+
 ## 1.0.0 - 2025-11-21
 
 ### Added

--- a/modules/json/README.md
+++ b/modules/json/README.md
@@ -1,3 +1,7 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/TrustBound/dream/main/ricky_and_lucy.png" alt="Dream Logo" width="200">
+</div>
+
 # dream_json
 
 **JSON encoding utilities for Gleam applications.**

--- a/modules/json/gleam.toml
+++ b/modules/json/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream_json"
-version = "1.0.0"
+version = "1.0.1"
 description = "JSON encoding utilities for Gleam applications"
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }

--- a/modules/opensearch/CHANGELOG.md
+++ b/modules/opensearch/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `dream_opensearch` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1 - 2025-11-22
+
+### Fixed
+- Fixed logo display on hex.pm by using full GitHub URL
+- Added Dream logo to README
+
 ## 1.0.0 - 2025-11-21
 
 ### Added

--- a/modules/opensearch/README.md
+++ b/modules/opensearch/README.md
@@ -1,3 +1,7 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/TrustBound/dream/main/ricky_and_lucy.png" alt="Dream Logo" width="200">
+</div>
+
 # dream_opensearch
 
 **Simple OpenSearch client for Gleam.**

--- a/modules/opensearch/gleam.toml
+++ b/modules/opensearch/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream_opensearch"
-version = "1.0.0"
+version = "1.0.1"
 description = "Simple OpenSearch client for Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }

--- a/modules/postgres/CHANGELOG.md
+++ b/modules/postgres/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `dream_postgres` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1 - 2025-11-22
+
+### Fixed
+- Fixed logo display on hex.pm by using full GitHub URL
+- Added Dream logo to README
+
 ## 1.0.0 - 2025-11-21
 
 ### Added

--- a/modules/postgres/README.md
+++ b/modules/postgres/README.md
@@ -1,3 +1,7 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/TrustBound/dream/main/ricky_and_lucy.png" alt="Dream Logo" width="200">
+</div>
+
 # dream_postgres
 
 **PostgreSQL utilities for Gleam with type-safe query helpers.**

--- a/modules/postgres/gleam.toml
+++ b/modules/postgres/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream_postgres"
-version = "1.0.0"
+version = "1.0.1"
 description = "PostgreSQL utilities for Gleam with type-safe query helpers"
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }

--- a/releases/release-1.0.1.md
+++ b/releases/release-1.0.1.md
@@ -1,0 +1,67 @@
+# Dream 1.0.1 Release Notes
+
+**Release Date:** November 22, 2025
+
+Dream 1.0.1 is a patch release that fixes logo display issues on Hex.pm for all Dream packages. This ensures proper branding and visual consistency when viewing package documentation on Hex.pm.
+
+## What's Fixed
+
+### Logo Display on Hex.pm
+
+Fixed broken logo images on Hex.pm package pages by updating README files to use full GitHub URLs instead of relative paths.
+
+**Changed in all packages:**
+- Main `dream` package
+- `dream_config`
+- `dream_ets`
+- `dream_http_client`
+- `dream_json`
+- `dream_opensearch`
+- `dream_postgres`
+
+**Technical Details:**
+- Updated logo image source from relative path (`ricky_and_lucy.png`) to full GitHub URL (`https://raw.githubusercontent.com/TrustBound/dream/main/ricky_and_lucy.png`)
+- Added Dream logo to all module README files for consistent branding across the ecosystem
+- Logos now display correctly on Hex.pm, GitHub, and any other platform rendering the README
+
+## Upgrading
+
+Update your dependencies to 1.0.1:
+
+```toml
+[dependencies]
+dream = ">= 1.0.1 and < 2.0.0"
+dream_config = ">= 1.0.1 and < 2.0.0"
+dream_ets = ">= 1.0.1 and < 2.0.0"
+dream_http_client = ">= 1.0.1 and < 2.0.0"
+dream_json = ">= 1.0.1 and < 2.0.0"
+dream_opensearch = ">= 1.0.1 and < 2.0.0"
+dream_postgres = ">= 1.0.1 and < 2.0.0"
+```
+
+Then run:
+```bash
+gleam deps download
+```
+
+**Note:** This is a documentation-only release. No code changes were made. Upgrading is optional but recommended for consistency with published documentation.
+
+## No Breaking Changes
+
+This release contains no breaking changes or code modifications. All functionality remains identical to 1.0.0.
+
+## Documentation
+
+All packages are available with updated documentation on HexDocs:
+- [dream](https://hexdocs.pm/dream)
+- [dream_config](https://hexdocs.pm/dream_config)
+- [dream_http_client](https://hexdocs.pm/dream_http_client)
+- [dream_postgres](https://hexdocs.pm/dream_postgres)
+- [dream_opensearch](https://hexdocs.pm/dream_opensearch)
+- [dream_json](https://hexdocs.pm/dream_json)
+- [dream_ets](https://hexdocs.pm/dream_ets)
+
+---
+
+**Full Changelog:** [CHANGELOG.md](https://github.com/TrustBound/dream/blob/main/CHANGELOG.md)
+


### PR DESCRIPTION
## Why

When Dream and its modules were published to hex.pm, the logos weren't displaying correctly on the package pages. This happened because the README files were using relative image paths that work on GitHub but break on hex.pm. Without access to the repository's files, hex.pm couldn't load the images, leaving all our package pages with broken image links. Additionally, the individual module packages didn't have the Dream logo at all, making the ecosystem look inconsistent and less professional.

## What

This release (v1.0.1) fixes the logo display issues across all packages:

1. **Fixed main package logo** - Updated the Dream README to use a full GitHub URL instead of a relative path
2. **Added logos to all modules** - Added the Dream logo to all 6 module READMEs (dream_config, dream_ets, dream_http_client, dream_json, dream_opensearch, dream_postgres)
3. **Version bump** - Bumped all packages from 1.0.0 to 1.0.1 to reflect this documentation fix
4. **Updated documentation** - Updated all CHANGELOG files and created release notes

## How

The fix was straightforward - changed image references from:
```markdown
<img src="ricky_and_lucy.png" alt="Dream Logo">
```

To:
```markdown
<img src="https://raw.githubusercontent.com/TrustBound/dream/main/ricky_and_lucy.png" alt="Dream Logo">
```

This full GitHub URL works everywhere - GitHub, hex.pm, and any other platform that renders our README files. The URL points to GitHub's raw content CDN, which serves the actual image file.

All version numbers across the main package and 6 modules were bumped to 1.0.1, with appropriate CHANGELOG entries and release documentation.

---

**Technical Details:**

This is a patch release (documentation-only changes, no code modifications). All packages now have consistent branding and will display correctly on hex.pm when republished.

Files changed: 23 files (gleam.toml, README.md, and CHANGELOG.md for all packages, plus new release notes)