### PR TITLE
Hotfix: Clean build cache after restoring dependencies

### DIFF
--- a/.github/actions/restore-dream-deps/action.yml
+++ b/.github/actions/restore-dream-deps/action.yml
@@ -15,5 +15,7 @@ runs:
       run: |
         if [ -f gleam.toml.bak ]; then
           mv gleam.toml.bak gleam.toml
+          # Clean build cache to avoid conflicts with restored dependencies
+          gleam clean
         fi
 


### PR DESCRIPTION
## Problem

The module publish workflow is failing with:

```
error: File IO failure
An error occurred while trying to read this file:
    /home/runner/work/dream/dream/modules/opensearch/build/packages/dream_http_client/gleam.toml
The error message from the file IO library was:
    No such file or directory (os error 2)
```

## Root Cause

When publishing modules that depend on other Dream modules:

1. Tests run with **local path dependencies** (gleam.toml is patched)
2. Build cache contains references to local module paths
3. Original gleam.toml is **restored** (points to Hex dependencies)
4. Publish step tries to build but **build cache still references local paths**
5. Gleam can't find the local files → error

## Solution

Run `gleam clean` after restoring the original gleam.toml to clear the build cache. This ensures the publish step starts fresh with the correct Hex dependencies.

## Files Changed

- `.github/actions/restore-dream-deps/action.yml` - Added `gleam clean` after restoring

## Testing

This can be verified by merging and watching the publish workflow succeed when it runs.