### PR TITLE
Fix Publishing Workflow to Check Hex Before Attempting Republish

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -75,21 +75,53 @@ jobs:
             echo "should_publish=true" >> $GITHUB_OUTPUT
             exit 0
           fi
-
+          
           # Get current version
           CURRENT_VERSION=$(grep '^version = ' gleam.toml | sed 's/version = "\(.*\)"/\1/')
           echo "Current Dream version: $CURRENT_VERSION"
 
           # Check if this version already exists on Hex
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://hex.pm/api/packages/dream/releases/$CURRENT_VERSION")
-
-          if [ "$HTTP_STATUS" = "200" ]; then
-            echo "Version $CURRENT_VERSION already published to Hex, skipping publish"
-            echo "should_publish=false" >> $GITHUB_OUTPUT
-          else
-            echo "Version $CURRENT_VERSION not found on Hex (HTTP $HTTP_STATUS), will publish"
-            echo "should_publish=true" >> $GITHUB_OUTPUT
+          # Use --max-time to prevent hanging, --retry for transient failures
+          HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+            --max-time 10 \
+            --retry 3 \
+            --retry-delay 2 \
+            "https://hex.pm/api/packages/dream/releases/$CURRENT_VERSION")
+          CURL_EXIT=$?
+          
+          # Check if curl itself failed (network issues, timeout, etc)
+          if [ $CURL_EXIT -ne 0 ]; then
+            echo "Error: Failed to check Hex API (curl exit code: $CURL_EXIT)"
+            echo "This could be a network issue or Hex API timeout"
+            exit 1
           fi
+          
+          # Handle HTTP status codes
+          case "$HTTP_RESPONSE" in
+            200)
+              echo "✓ Version $CURRENT_VERSION already exists on Hex, skipping publish"
+              echo "should_publish=false" >> $GITHUB_OUTPUT
+              ;;
+            404)
+              echo "✓ Version $CURRENT_VERSION not found on Hex, will publish"
+              echo "should_publish=true" >> $GITHUB_OUTPUT
+              ;;
+            429)
+              echo "Error: Hex API rate limit exceeded (HTTP 429)"
+              echo "Please wait a few minutes and try again"
+              exit 1
+              ;;
+            5*)
+              echo "Error: Hex API server error (HTTP $HTTP_RESPONSE)"
+              echo "This is likely a temporary Hex issue, please try again later"
+              exit 1
+              ;;
+            *)
+              echo "Error: Unexpected HTTP status from Hex API: $HTTP_RESPONSE"
+              echo "Cannot determine if version exists, failing safely"
+              exit 1
+              ;;
+          esac
 
       - name: Install Erlang and Gleam
         if: steps.version_check.outputs.should_publish == 'true'


### PR DESCRIPTION
## Problem

The publishing workflow failed when merging the 2.1.0 hotfix to main with this error:

```
Version already published
Version v2.1.0 has already been published.
```

This happened because the version check only compared the current commit to the previous commit in git—it never checked if the version already exists on Hex. When hotfixes are merged that don't change the version number, the workflow attempts to republish the same version.

---

## Why This Matters

**Immediate Impact:**
- Blocks hotfix merges unless version numbers are manually bumped (wasteful)
- Causes CI failures on legitimate merges
- Requires manual intervention to retry workflows

**Root Cause:**
- The old check: "Did the version change in git?" 
- The correct check: "Does this version exist on Hex?"
- These are different questions with different answers

---

## What Changed

### Core Fix: Check Hex API Instead of Git History

**Before:**
```bash
# Compare current gleam.toml version to previous commit
if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
  publish
fi
```

**After:**
```bash
# Query Hex API to see if version exists
HTTP_STATUS=$(curl "https://hex.pm/api/packages/dream/releases/$VERSION")
if [ "$HTTP_STATUS" = "200" ]; then
  skip  # Already published
else
  publish  # Not published yet
fi
```

### Robust Error Handling

The initial fix was too simplistic. Production CI needs to handle:
- **Network failures** → Timeout after 10 seconds
- **Transient errors** → Auto-retry 3 times with 2s delay
- **API issues** → Distinguish between "doesn't exist" vs "API down"
- **Rate limits** → Explicit 429 handling with clear message

**HTTP Status Handling:**
- `200` → Version exists on Hex, skip publish ✓
- `404` → Version doesn't exist, proceed with publish ✓
- `429` → Rate limit exceeded, fail with helpful message (can retry manually)
- `5xx` → Hex server error, fail with retry suggestion (transient issue)
- Other → Unexpected response, fail safely (don't guess)

### Fail-Safe Philosophy

If we **cannot confidently determine** whether the version exists on Hex (network issue, API error, unexpected response), the workflow **fails** rather than:
- Publishing a duplicate (causes Hex error)
- Skipping a needed publish (users don't get the release)

Failures can be manually retried once the issue resolves (usually seconds/minutes for transient problems).

---

## How It Works

```bash
# 1. Query Hex API with resilience
HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
  --max-time 10 \
  --retry 3 \
  --retry-delay 2 \
  "https://hex.pm/api/packages/dream/releases/$CURRENT_VERSION")

# 2. Check curl succeeded
if [ $CURL_EXIT -ne 0 ]; then
  echo "Error: Failed to check Hex API"
  exit 1  # Network/timeout issue
fi

# 3. Handle response
case "$HTTP_RESPONSE" in
  200) skip_publish ;;      # Already exists
  404) proceed_publish ;;   # Doesn't exist
  429) fail_rate_limit ;;   # Too many requests
  5*) fail_hex_down ;;      # Server error
  *) fail_unexpected ;;     # Unknown status
esac
```

---

## Testing

**Manual verification:**
- Tested with published version (2.1.0): Returns 200, skips ✓
- Tested with unpublished version (9.9.9): Returns 404, publishes ✓
- Curl timeout/retry flags validated against Hex API

**Production validation:**
- Will be verified when next version is published to main
- Safe to merge now since it only affects future publishes

---

## Consistency

This brings Dream's version check in line with module publishing:
- **Modules:** Already use `.github/actions/check-hex-version` which queries Hex API
- **Dream:** Was using git commit comparison (now fixed)

Both now use the same reliable approach: **check Hex, not git**.

---

## Related

- Fixes the issue that blocked the 2.1.0 hotfix merge
- No changes to actual publishing logic, only the version check
- FORCE_PUBLISH secret still works to bypass all checks