### PR TITLE
dream_http_client Release 4.1.0: Safer recordings

### DIFF
--- a/modules/http_client/CHANGELOG.md
+++ b/modules/http_client/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `dream_http_client` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.1.0 - 2026-01-28
+
+### Changed
+
+- Recording fixtures are written atomically to prevent partial reads during capture.
+
+### Added
+
+- Storage test coverage for atomic fixture writes and cleanup.
+
 ## 4.0.0 - 2025-12-29
 
 ### Breaking Changes

--- a/modules/http_client/README.md
+++ b/modules/http_client/README.md
@@ -432,6 +432,7 @@ mocks/api/POST_localhost__text_c7d8e9_4f22bc.json
 **Benefits:**
 
 - **O(1) write performance** - No read-modify-write cycles
+- **Atomic fixture writes** - Readers never see partial recordings
 - **Concurrent tests work** - No file contention between parallel tests
 - **Easy inspection** - Each recording is a separate, readable file
 - **Version control friendly** - Individual files show clear diffs

--- a/modules/http_client/gleam.toml
+++ b/modules/http_client/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream_http_client"
-version = "4.0.0"
+version = "4.1.0"
 description = "Type-safe HTTP client for Gleam with streaming support"
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }

--- a/modules/http_client/releases/release-4.1.0.md
+++ b/modules/http_client/releases/release-4.1.0.md
@@ -1,0 +1,31 @@
+# dream_http_client 4.1.0 Release Notes
+
+**Release Date:** January 28, 2026
+
+dream_http_client 4.1.0 makes recording fixtures safer by writing them atomically, so readers never observe partial files during capture.
+
+## Key Highlights
+
+- **Atomic fixture writes**: recordings are written to a temp file and renamed into place.
+- **Safer concurrent reads**: readers only see complete JSON files.
+- **Test coverage**: storage tests verify atomic behavior and cleanup.
+
+## Changes
+
+### Atomic Recording Writes
+
+Recording fixtures are now written atomically:
+
+- Write content to a temporary file
+- Rename into place once complete
+
+This prevents consumers from reading partially-written recordings during capture.
+
+## Upgrading
+
+Update your dependency:
+
+```toml
+[dependencies]
+dream_http_client = ">= 4.1.0 and < 5.0.0"
+```

--- a/modules/http_client/src/dream_http_client/client.gleam
+++ b/modules/http_client/src/dream_http_client/client.gleam
@@ -1035,35 +1035,41 @@ fn send_and_maybe_record(
 ) -> Result(String, String) {
   case send_client_request_to_httpc_with_meta(client_request) {
     Ok(#(status, headers, body)) -> {
-      record_blocking_response_if_needed(
+      let recorded_response =
+        recording.BlockingResponse(status: status, headers: headers, body: body)
+      let response_for_recording = case
+        recorder.is_record_mode(recorder_instance)
+      {
+        True ->
+          recorder.transform_response(
+            recorder_instance,
+            recorded_request,
+            recorded_response,
+          )
+        False -> recorded_response
+      }
+
+      record_response_if_needed(
         recorder_instance,
         recorded_request,
-        status,
-        headers,
-        body,
+        response_for_recording,
       )
+
       Ok(body)
     }
     Error(error_message) -> Error(error_message)
   }
 }
 
-fn record_blocking_response_if_needed(
+fn record_response_if_needed(
   recorder_instance: recorder.Recorder,
   recorded_request: recording.RecordedRequest,
-  status: Int,
-  headers: List(#(String, String)),
-  body: String,
+  response: recording.RecordedResponse,
 ) -> Nil {
   case recorder.is_record_mode(recorder_instance) {
     True -> {
-      let recorded_response =
-        recording.BlockingResponse(status: status, headers: headers, body: body)
       let recorder_entry =
-        recording.Recording(
-          request: recorded_request,
-          response: recorded_response,
-        )
+        recording.Recording(request: recorded_request, response: response)
       recorder.add_recording(recorder_instance, recorder_entry)
     }
     False -> Nil

--- a/modules/http_client/src/dream_http_client/dream_http_client_fs_shim.erl
+++ b/modules/http_client/src/dream_http_client/dream_http_client_fs_shim.erl
@@ -1,0 +1,29 @@
+-module(dream_http_client_fs_shim).
+
+-export([atomic_write/2]).
+
+%% @doc Atomically write file content.
+%%
+%% Writes content to a temporary file and renames it into place so readers
+%% never observe partial content.
+atomic_write(Path, Content) when is_binary(Path), is_binary(Content) ->
+    Unique = erlang:unique_integer([monotonic, positive]),
+    Tmp = <<Path/binary, ".tmp.", (integer_to_binary(Unique))/binary>>,
+    case file:write_file(Tmp, Content) of
+        ok ->
+            case file:rename(Tmp, Path) of
+                ok ->
+                    {ok, nil};
+                {error, Reason} ->
+                    _ = file:delete(Tmp),
+                    {error, format_reason(Reason)}
+            end;
+        {error, Reason} ->
+            {error, format_reason(Reason)}
+    end;
+atomic_write(Path, Content) ->
+    %% Normalize non-binary inputs to binaries for safety
+    atomic_write(iolist_to_binary(Path), iolist_to_binary(Content)).
+
+format_reason(Reason) ->
+    iolist_to_binary(io_lib:format("~p", [Reason])).

--- a/modules/http_client/src/dream_http_client/recorder.gleam
+++ b/modules/http_client/src/dream_http_client/recorder.gleam
@@ -428,10 +428,31 @@ fn handle_recorder_message(
             )
           let key = state.key(transformed.request)
 
-          let new_recordings = case dict.get(state.recordings, key) {
-            Ok(existing) ->
-              dict.insert(state.recordings, key, [transformed, ..existing])
-            Error(_) -> dict.insert(state.recordings, key, [transformed])
+          let should_save = case dict.get(state.recordings, key) {
+            Error(_) -> True
+            Ok(existing) -> {
+              let duplicate =
+                existing
+                |> list.any(fn(rec) {
+                  let recording.Recording(_, response) = rec
+                  responses_equal(response, transformed.response)
+                })
+              case duplicate {
+                True -> False
+                False -> True
+              }
+            }
+          }
+
+          let new_recordings = case should_save {
+            True -> {
+              case dict.get(state.recordings, key) {
+                Ok(existing) ->
+                  dict.insert(state.recordings, key, [transformed, ..existing])
+                Error(_) -> dict.insert(state.recordings, key, [transformed])
+              }
+            }
+            False -> state.recordings
           }
 
           let new_state =
@@ -444,20 +465,24 @@ fn handle_recorder_message(
               recordings: new_recordings,
             )
 
-          // Save immediately if in Record mode
-          case
-            storage.save_recording_immediately(
-              state.directory,
-              transformed,
-              key,
-            )
-          {
-            Ok(_) -> actor.continue(new_state)
-            Error(save_error) -> {
-              // Log error but don't crash - keep in-memory recording
-              io.println_error("Failed to save recording: " <> save_error)
-              actor.continue(new_state)
-            }
+          case should_save {
+            False -> actor.continue(new_state)
+            True ->
+              // Save immediately if in Record mode
+              case
+                storage.save_recording_immediately(
+                  state.directory,
+                  transformed,
+                  key,
+                )
+              {
+                Ok(_) -> actor.continue(new_state)
+                Error(save_error) -> {
+                  // Log error but don't crash - keep in-memory recording
+                  io.println_error("Failed to save recording: " <> save_error)
+                  actor.continue(new_state)
+                }
+              }
           }
         }
         _ -> actor.continue(state)
@@ -484,17 +509,26 @@ fn handle_recorder_message(
             }
             Ok(records) -> {
               let count = list.length(records)
-              process.send(
-                reply_to,
-                FoundRecording(Error(
-                  "Ambiguous recording match for key: "
-                  <> key
-                  <> " ("
-                  <> int.to_string(count)
-                  <> " recordings)",
-                )),
-              )
-              actor.continue(state)
+              let resolved = resolve_ambiguous_recordings(records)
+              case resolved {
+                Ok(option.Some(rec)) -> {
+                  process.send(reply_to, FoundRecording(Ok(option.Some(rec))))
+                  actor.continue(state)
+                }
+                _ -> {
+                  process.send(
+                    reply_to,
+                    FoundRecording(Error(
+                      "Ambiguous recording match for key: "
+                      <> key
+                      <> " ("
+                      <> int.to_string(count)
+                      <> " recordings)",
+                    )),
+                  )
+                  actor.continue(state)
+                }
+              }
             }
           }
         }
@@ -518,6 +552,13 @@ fn handle_recorder_message(
       process.send(reply_to, ModeIsRecord(is_record))
       actor.continue(state)
     }
+    TransformResponse(request, response, reply_to) -> {
+      let transformed_request = state.request_transformer(request)
+      let transformed =
+        state.response_transformer(transformed_request, response)
+      process.send(reply_to, TransformedResponse(transformed))
+      actor.continue(state)
+    }
     Stop(reply_to) -> {
       // No need to save - recordings already saved immediately
       process.send(reply_to, Stopped(Ok(Nil)))
@@ -534,6 +575,11 @@ type RecorderMessage {
   )
   GetRecordings(reply_to: process.Subject(RecorderResponse))
   CheckMode(reply_to: process.Subject(RecorderResponse))
+  TransformResponse(
+    request: recording.RecordedRequest,
+    response: recording.RecordedResponse,
+    reply_to: process.Subject(RecorderResponse),
+  )
   Stop(reply_to: process.Subject(RecorderResponse))
 }
 
@@ -541,6 +587,7 @@ type RecorderResponse {
   FoundRecording(Result(option.Option(recording.Recording), String))
   GotRecordings(List(recording.Recording))
   ModeIsRecord(Bool)
+  TransformedResponse(recording.RecordedResponse)
   Stopped(Result(Nil, String))
 }
 
@@ -552,6 +599,88 @@ fn flatten_recordings(
     list.fold(recs, acc, fn(acc2, r) { [r, ..acc2] })
   })
   |> list.reverse
+}
+
+fn resolve_ambiguous_recordings(
+  records: List(recording.Recording),
+) -> Result(option.Option(recording.Recording), Nil) {
+  case records {
+    [] -> Ok(option.None)
+    [first, ..rest] -> {
+      let recording.Recording(_, first_response) = first
+      let all_equal =
+        rest
+        |> list.all(fn(rec) {
+          let recording.Recording(_, response) = rec
+          responses_equal(first_response, response)
+        })
+      case all_equal {
+        True -> Ok(option.Some(first))
+        False -> Ok(option.None)
+      }
+    }
+  }
+}
+
+fn responses_equal(
+  left: recording.RecordedResponse,
+  right: recording.RecordedResponse,
+) -> Bool {
+  case left, right {
+    recording.BlockingResponse(status_a, headers_a, body_a),
+      recording.BlockingResponse(status_b, headers_b, body_b)
+    ->
+      status_a == status_b
+      && headers_a == headers_b
+      && normalize_body_for_compare(body_a)
+      == normalize_body_for_compare(body_b)
+    _, _ -> False
+  }
+}
+
+fn normalize_body_for_compare(body: String) -> String {
+  case response_kind(body) {
+    "auth_result" -> normalize_auth_result_body(body)
+    _ -> body
+  }
+}
+
+fn response_kind(body: String) -> String {
+  case string.contains(body, "AuthenticationResult") {
+    True -> "auth_result"
+    False -> "other"
+  }
+}
+
+fn normalize_auth_result_body(body: String) -> String {
+  body
+  |> replace_json_string_value("AccessToken", "<REDACTED_TOKEN>")
+  |> replace_json_string_value("IdToken", "<REDACTED_TOKEN>")
+  |> replace_json_string_value("RefreshToken", "<REDACTED_TOKEN>")
+}
+
+fn replace_json_string_value(
+  body: String,
+  key: String,
+  replacement: String,
+) -> String {
+  let marker = "\"" <> key <> "\":\""
+  case string.contains(body, marker) {
+    False -> body
+    True -> {
+      let parts = string.split(body, marker)
+      case list.first(parts), list.drop(parts, 1) |> list.first() {
+        Ok(prefix), Ok(rest) -> {
+          case string.split(rest, "\"") {
+            [_, ..tail] ->
+              prefix <> marker <> replacement <> "\"" <> string.join(tail, "\"")
+            _ -> body
+          }
+        }
+        _, _ -> body
+      }
+    }
+  }
 }
 
 /// Add a recording to the recorder
@@ -664,6 +793,39 @@ pub fn is_record_mode(recorder: Recorder) -> Bool {
         <> string.inspect(timeout_error),
       )
       False
+    }
+  }
+}
+
+/// Apply the recorder's response transformer to a response.
+pub fn transform_response(
+  recorder: Recorder,
+  request: recording.RecordedRequest,
+  response: recording.RecordedResponse,
+) -> recording.RecordedResponse {
+  let Recorder(subject) = recorder
+  let reply_subject = process.new_subject()
+  process.send(subject, TransformResponse(request, response, reply_subject))
+
+  let selector =
+    process.new_selector()
+    |> process.select_map(reply_subject, identity_recorder_response)
+
+  case process.selector_receive(selector, 1000) {
+    Ok(TransformedResponse(transformed)) -> transformed
+    Ok(unexpected_message) -> {
+      io.println_error(
+        "Recorder returned unexpected response to TransformResponse: "
+        <> string.inspect(unexpected_message),
+      )
+      response
+    }
+    Error(timeout_error) -> {
+      io.println_error(
+        "Recorder did not respond to TransformResponse within 1 second: "
+        <> string.inspect(timeout_error),
+      )
+      response
     }
   }
 }

--- a/modules/http_client/src/dream_http_client/storage.gleam
+++ b/modules/http_client/src/dream_http_client/storage.gleam
@@ -173,8 +173,8 @@ pub fn save_recording_immediately(
     let filename = build_filename(rec.request, key, json_string)
     let file_path = directory <> "/" <> filename
 
-    // Write to file
-    case simplifile.write(file_path, json_string) {
+    // Write to file atomically so readers never see partial content
+    case atomic_write(file_path, json_string) {
       Ok(Nil) -> Ok(Nil)
       Error(write_error) -> {
         Error(
@@ -411,3 +411,6 @@ fn generate_hash(input: String) -> String {
   bit_array.base16_encode(hash_bits)
   |> string.lowercase()
 }
+
+@external(erlang, "dream_http_client_fs_shim", "atomic_write")
+fn atomic_write(file_path: String, content: String) -> Result(Nil, String)

--- a/modules/http_client/test/start_stream_test.gleam
+++ b/modules/http_client/test/start_stream_test.gleam
@@ -65,11 +65,7 @@ pub fn start_stream_calls_on_start_callback_test() {
   let assert Ok(_handle) = client.start_stream(request)
 
   // Assert - on_start was called
-  case process.receive(started_subject, 1000) {
-    Ok(True) -> Nil
-    Ok(False) -> should.fail()
-    Error(Nil) -> should.fail()
-  }
+  wait_for_true(started_subject, 5) |> should.be_true()
 }
 
 pub fn start_stream_calls_on_end_callback_test() {
@@ -156,5 +152,18 @@ fn collect_from_subject(subject: process.Subject(a), acc: List(a)) -> List(a) {
   case process.receive(subject, 50) {
     Ok(item) -> collect_from_subject(subject, [item, ..acc])
     Error(Nil) -> list.reverse(acc)
+  }
+}
+
+fn wait_for_true(subject: process.Subject(Bool), attempts: Int) -> Bool {
+  case attempts <= 0 {
+    True -> False
+    False -> {
+      case process.receive(subject, 200) {
+        Ok(True) -> True
+        Ok(False) -> wait_for_true(subject, attempts - 1)
+        Error(Nil) -> wait_for_true(subject, attempts - 1)
+      }
+    }
   }
 }

--- a/modules/http_client/test/storage_test.gleam
+++ b/modules/http_client/test/storage_test.gleam
@@ -133,6 +133,29 @@ pub fn save_recording_immediately_appends_to_existing_test() {
   list.length(loaded) |> should.equal(2)
 }
 
+pub fn save_recording_immediately_writes_atomically_without_temp_files_test() {
+  // Arrange
+  let directory = temp_directory("atomic_write")
+  let rec = create_test_recording()
+  let key_fn = default_key()
+
+  // Act
+  let assert Ok(_) =
+    storage.save_recording_immediately(directory, rec, key_fn(rec.request))
+
+  // Assert - no temp files left behind
+  let assert Ok(files) = simplifile.read_directory(directory)
+  let temp_files =
+    list.filter(files, fn(file) { string.contains(file, ".tmp.") })
+  list.length(temp_files) |> should.equal(0)
+
+  // Assert - final JSON file is readable and complete
+  let json_files = list.filter(files, fn(f) { string.ends_with(f, ".json") })
+  let assert [filename] = json_files
+  let assert Ok(content) = simplifile.read(directory <> "/" <> filename)
+  recording.decode_recording_file(content) |> should.be_ok()
+}
+
 pub fn different_query_params_create_different_files_test() {
   // Arrange
   let directory = temp_directory("query_test")


### PR DESCRIPTION
## Summary
- roll up the latest dream_http_client changes into a release PR
- include atomic fixture writes and recorder response handling improvements
- refresh module docs and tests for the 4.1.0 release

## Why
This release makes recorded fixtures safer to consume (no partial reads) and ensures recorder behavior is predictable under duplicate or ambiguous recordings.

## What
Pulls the latest develop changes for dream_http_client into main, including atomic writes, recorder response handling tweaks, and updated docs/tests.

## How
Merged develop into this PR targeting main, with updated module versioning and release notes for 4.1.0.

## Test plan
- CI