### PR TITLE
Release 2.3.2: Clearer startup errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.2] - 2026-02-04
+
+### Added
+
+- Added `setup-integration-dbs` Makefile target to mirror CI database setup locally
+
+### Fixed
+
+- Server startup now fails fast with a clear error when the port is already in use
+- Thanks to [daniellionel01](https://github.com/daniellionel01) for reporting the issue
+
 ## [2.3.1] - 2025-12-13
 
 ### Added
@@ -464,7 +475,8 @@ Special thanks to [Louis Pilfold](https://github.com/lpil) for suggesting the ra
 - All code examples now include proper imports
 - Improved documentation tone and consistency
 
-[Unreleased]: https://github.com/TrustBound/dream/compare/v2.3.1...HEAD
+[Unreleased]: https://github.com/TrustBound/dream/compare/v2.3.2...HEAD
+[2.3.2]: https://github.com/TrustBound/dream/compare/v2.3.1...v2.3.2
 [2.3.1]: https://github.com/TrustBound/dream/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/TrustBound/dream/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/TrustBound/dream/compare/v2.1.0...v2.2.0

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Dream Library Development Makefile
 # For example-specific commands, see individual example directories
 
-.PHONY: test test-dream test-unit test-integration clean build format docs check install-hooks
+.PHONY: test test-dream test-unit test-integration setup-integration-dbs clean build format docs check install-hooks
 
 # Run all tests (unit + integration)
 test:
@@ -75,4 +75,15 @@ test-integration:
 	done
 	@echo ""
 	@echo "✅ All integration tests passed!"
+
+# Set up local PostgreSQL and migrations for examples that require it
+setup-integration-dbs:
+	@echo "=== Setting up PostgreSQL for integration tests ==="
+	@cd examples/database && make db-up
+	@cd examples/database && docker-compose exec -T postgres psql -U postgres -c "DROP DATABASE IF EXISTS dream_example_database_db;" > /dev/null 2>&1
+	@cd examples/database && docker-compose exec -T postgres psql -U postgres -c "CREATE DATABASE dream_example_database_db;" > /dev/null 2>&1
+	@cd examples/database && docker-compose exec -T postgres psql -U postgres -c "DROP DATABASE IF EXISTS dream_example_multi_format_db;" > /dev/null 2>&1
+	@cd examples/database && docker-compose exec -T postgres psql -U postgres -c "CREATE DATABASE dream_example_multi_format_db;" > /dev/null 2>&1
+	@cd examples/database && export DATABASE_URL=postgres://postgres:postgres@localhost:5435/dream_example_database_db && gleam run -m cigogne all
+	@cd examples/multi_format && export DATABASE_URL=postgres://postgres:postgres@localhost:5435/dream_example_multi_format_db && gleam run -m cigogne all
 

--- a/examples/websocket_chat/src/templates/components/messages_container.gleam
+++ b/examples/websocket_chat/src/templates/components/messages_container.gleam
@@ -9,6 +9,7 @@ pub fn render_tree() -> StringTree {
       tree,
       "<div class=\"messages\" id=\"messages\"></div>
 
+
 ",
     )
 

--- a/examples/websocket_chat/src/templates/components/welcome_screen.gleam
+++ b/examples/websocket_chat/src/templates/components/welcome_screen.gleam
@@ -33,6 +33,7 @@ pub fn render_tree(
     </div>
 </div>
 
+
 ",
     )
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream"
-version = "2.3.1"
+version = "2.3.2"
 description = "Clean, composable web development for Gleam. No magic."
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }

--- a/modules/ets/manifest.toml
+++ b/modules/ets/manifest.toml
@@ -13,5 +13,5 @@ packages = [
 [requirements]
 dream_test = { version = ">= 1.0.3 and < 2.0.0" }
 gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
-gleam_json = { version = ">= 2.2.0 and < 4.0.0" }
-gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
+gleam_json = { version = ">= 3.0.1 and < 4.0.0" }
+gleam_stdlib = { version = ">= 0.60.0 and < 1.0.0" }

--- a/releases/release-2.3.2.md
+++ b/releases/release-2.3.2.md
@@ -1,0 +1,46 @@
+# Dream 2.3.2 Release Notes
+
+**Release Date:** February 4, 2026
+
+This release focuses on startup clarity and smoother local testing.
+
+## Key Highlights
+
+- **Fail-fast startup**: Servers now report a clear error when a port is already in use
+- **Local test parity with CI**: One Makefile target prepares the integration databases
+- **Cleaner server startup flow**: Internal helpers keep the public API simple
+
+## Thanks
+
+Thanks to [daniellionel01](https://github.com/daniellionel01) for reporting the issue.
+
+## Fixed
+
+Dream now detects port conflicts before starting the Mist server and returns a
+direct, actionable error message. No more “it started” when it didn’t.
+
+## Added
+
+A new `setup-integration-dbs` target prepares the example databases and
+applies migrations, matching CI’s database setup steps.
+
+## Upgrading
+
+Update your dependencies:
+
+```toml
+[dependencies]
+dream = ">= 2.3.2 and < 3.0.0"
+```
+
+Then run:
+
+```bash
+gleam deps download
+```
+
+## Documentation
+
+- [dream](https://hexdocs.pm/dream) - v2.3.2
+
+---

--- a/src/dream/servers/mist/port_probe.gleam
+++ b/src/dream/servers/mist/port_probe.gleam
@@ -1,0 +1,76 @@
+//// Internal port availability probe for Mist servers.
+////
+//// Uses a short TCP connect attempt to determine if a port is already in use.
+
+import gleam/dynamic.{type Dynamic}
+import gleam/erlang/atom
+import gleam/erlang/charlist
+import gleam/option
+import gleam/result
+
+@external(erlang, "gleam_stdlib", "identity")
+fn to_dynamic(value: a) -> Dynamic
+
+@external(erlang, "inet", "parse_ipv4_address")
+fn parse_ipv4_address(
+  value: charlist.Charlist,
+) -> Result(#(Int, Int, Int, Int), atom.Atom)
+
+@external(erlang, "gen_tcp", "connect")
+fn tcp_connect(
+  address: #(Int, Int, Int, Int),
+  port: Int,
+  options: List(Dynamic),
+  timeout: Int,
+) -> Result(Dynamic, Dynamic)
+
+@external(erlang, "gen_tcp", "close")
+fn tcp_close(socket: Dynamic) -> Result(Nil, Dynamic)
+
+/// Check whether a port is already in use on the given interface.
+///
+/// This performs a short TCP connect attempt and returns `True` when a listener
+/// is already bound, `False` otherwise. It defaults to `"localhost"` when no
+/// interface is provided.
+///
+/// ## Parameters
+///
+/// - `interface`: The interface to check. Use `Some("127.0.0.1")`, `Some("0.0.0.0")`,
+///   or `Some("localhost")`. Pass `None` to use `"localhost"`.
+/// - `port`: The TCP port number to probe.
+///
+/// This function is intended for internal server startup checks.
+///
+/// ## Example
+///
+/// ```gleam
+/// import gleam/option.{None}
+/// import dream/servers/mist/port_probe
+///
+/// let in_use = port_probe.is_in_use(None, 3000)
+/// ```
+pub fn is_in_use(interface: option.Option(String), port: Int) -> Bool {
+  let host = case interface {
+    option.Some(value) -> value
+    option.None -> "localhost"
+  }
+
+  let connect_options = [to_dynamic(#(atom.create("active"), False))]
+
+  let ipv4_addr = case host {
+    "localhost" | "127.0.0.1" | "0.0.0.0" -> Ok(#(127, 0, 0, 1))
+    _ -> parse_ipv4_address(charlist.from_string(host))
+  }
+
+  ipv4_addr
+  |> result.map(fn(address) {
+    case tcp_connect(address, port, connect_options, 200) {
+      Ok(socket) -> {
+        let _ = tcp_close(socket)
+        True
+      }
+      Error(_) -> False
+    }
+  })
+  |> result.unwrap(False)
+}

--- a/src/dream/servers/mist/server.gleam
+++ b/src/dream/servers/mist/server.gleam
@@ -46,11 +46,16 @@ import dream/context.{type EmptyContext, EmptyContext}
 import dream/dream
 import dream/router.{type EmptyServices, type Router, EmptyServices}
 import dream/servers/mist/handler
+import dream/servers/mist/port_probe
 import gleam/bytes_tree
 import gleam/erlang/process
+import gleam/http/request as http_request
 import gleam/http/response as http_response
+import gleam/int
 import gleam/option
 import gleam/otp/actor
+import gleam/result
+import gleam/string
 import mist.{type Connection, type ResponseData, Bytes, start}
 
 /// Handle to a running server process
@@ -310,16 +315,6 @@ pub fn max_body_size(
   )
 }
 
-/// Helper function to update context with request_id
-/// This is a simple implementation that just returns the template context
-/// Most applications don't need request_id in their context
-/// If you need request_id, consider using middleware or logging
-fn update_context_with_request_id(ctx: context, _request_id: String) -> context {
-  // Just return the template context as-is
-  // Applications that need request_id can provide custom middleware
-  ctx
-}
-
 /// Start the server and listen for requests
 ///
 /// Starts the server on the specified port and blocks forever. This is what you call
@@ -349,57 +344,8 @@ pub fn listen(
   ),
   port: Int,
 ) -> Nil {
-  let _ = listen_internal(dream_instance, port, True)
-  Nil
-}
-
-/// Internal function to start the server with configurable blocking behavior
-/// Returns Result with Started info on success, or Error with StartError on failure
-fn listen_internal(
-  dream_instance: dream.Dream(
-    mist.Builder(Connection, ResponseData),
-    context,
-    services,
-  ),
-  port: Int,
-  block_forever: Bool,
-) -> Result(actor.Started(_), actor.StartError) {
-  // Extract router and services - panic if not set
-  let assert option.Some(router_instance) = dream.get_router(dream_instance)
-  let assert option.Some(services_instance) = dream.get_services(dream_instance)
-
-  // Create the handler with the router, context, and services
-  let handler_fn =
-    handler.create(
-      router_instance,
-      dream.get_max_body_size(dream_instance),
-      dream.get_context(dream_instance),
-      services_instance,
-      update_context_with_request_id,
-    )
-
-  // Create mist server with the handler
-  let server_with_handler = mist.new(handler_fn)
-
-  // Apply bind interface if configured
-  let server_with_interface = case dream.get_bind_interface(dream_instance) {
-    option.Some(interface) -> mist.bind(server_with_handler, interface)
-    option.None -> server_with_handler
-  }
-
-  // Set the port
-  let server_with_port = mist.port(server_with_interface, port)
-
-  case start(server_with_port) {
-    Ok(started) -> {
-      case block_forever {
-        True -> process.sleep_forever()
-        False -> Nil
-      }
-      Ok(started)
-    }
-    Error(err) -> Error(err)
-  }
+  listen_internal(dream_instance, port, True)
+  |> panic_on_start_error
 }
 
 /// Start the server and return a handle for stopping it
@@ -473,6 +419,127 @@ pub fn stop(handle: ServerHandle) -> Nil {
       // This allows the supervisor to clean up gracefully
       process.send_exit(process_pid)
       Nil
+    }
+  }
+}
+
+/// Helper function to update context with request_id
+/// This is a simple implementation that just returns the template context
+/// Most applications don't need request_id in their context
+/// If you need request_id, consider using middleware or logging
+fn update_context_with_request_id(ctx: context, _request_id: String) -> context {
+  // Just return the template context as-is
+  // Applications that need request_id can provide custom middleware
+  ctx
+}
+
+fn bind_label(interface: option.Option(String)) -> String {
+  option.unwrap(interface, "localhost")
+}
+
+fn port_in_use_error(port: Int, bind_label: String) -> actor.StartError {
+  let message =
+    "Port "
+    <> int.to_string(port)
+    <> " already in use on "
+    <> bind_label
+    <> ". Stop the process using that port or choose a different one."
+  actor.InitFailed(message)
+}
+
+fn build_handler(
+  dream_instance: dream.Dream(
+    mist.Builder(Connection, ResponseData),
+    context,
+    services,
+  ),
+  router_instance: Router(context, services),
+  services_instance: services,
+) -> fn(http_request.Request(Connection)) ->
+  http_response.Response(ResponseData) {
+  handler.create(
+    router_instance,
+    dream.get_max_body_size(dream_instance),
+    dream.get_context(dream_instance),
+    services_instance,
+    update_context_with_request_id,
+  )
+}
+
+fn build_server(
+  dream_instance: dream.Dream(
+    mist.Builder(Connection, ResponseData),
+    context,
+    services,
+  ),
+  handler_fn: fn(http_request.Request(Connection)) ->
+    http_response.Response(ResponseData),
+  port: Int,
+) -> mist.Builder(Connection, ResponseData) {
+  let server_with_handler = mist.new(handler_fn)
+  let server_with_interface = case dream.get_bind_interface(dream_instance) {
+    option.Some(interface) -> mist.bind(server_with_handler, interface)
+    option.None -> server_with_handler
+  }
+  mist.port(server_with_interface, port)
+}
+
+fn handle_blocking(block_forever: Bool) -> Nil {
+  case block_forever {
+    True -> process.sleep_forever()
+    False -> Nil
+  }
+}
+
+fn start_server(
+  server_with_port: mist.Builder(Connection, ResponseData),
+  block_forever: Bool,
+) -> Result(actor.Started(_), actor.StartError) {
+  start(server_with_port)
+  |> result.map(fn(started) {
+    handle_blocking(block_forever)
+    started
+  })
+}
+
+fn panic_on_start_error(result: Result(a, actor.StartError)) -> Nil {
+  case result {
+    Ok(_) -> Nil
+    Error(actor.InitFailed(message)) -> panic as message
+    Error(err) -> {
+      let message = "Failed to start server: " <> string.inspect(err)
+      panic as message
+    }
+  }
+}
+
+/// Internal function to start the server with configurable blocking behavior
+/// Returns Result with Started info on success, or Error with StartError on failure
+fn listen_internal(
+  dream_instance: dream.Dream(
+    mist.Builder(Connection, ResponseData),
+    context,
+    services,
+  ),
+  port: Int,
+  block_forever: Bool,
+) -> Result(actor.Started(_), actor.StartError) {
+  let bind_interface = dream.get_bind_interface(dream_instance)
+  let bind_interface_label = bind_label(bind_interface)
+
+  case port_probe.is_in_use(bind_interface, port) {
+    True -> Error(port_in_use_error(port, bind_interface_label))
+    False -> {
+      // Extract router and services - panic if not set
+      let assert option.Some(router_instance) = dream.get_router(dream_instance)
+      let assert option.Some(services_instance) =
+        dream.get_services(dream_instance)
+
+      let handler_fn =
+        build_handler(dream_instance, router_instance, services_instance)
+      let server_with_port = build_server(dream_instance, handler_fn, port)
+
+      start_server(server_with_port, block_forever)
     }
   }
 }

--- a/test/dream/servers/mist/server_test.gleam
+++ b/test/dream/servers/mist/server_test.gleam
@@ -9,6 +9,7 @@ import dream_test/unit.{type UnitTest, after_each, before_each, describe, it}
 import fixtures/hooks.{start_server, stop_server, test_server_port}
 import gleam/erlang/process
 import gleam/option.{None}
+import gleam/otp/actor
 import gleam/string
 
 // ============================================================================
@@ -125,6 +126,59 @@ fn lifecycle_tests() -> UnitTest {
           AssertionFailed(AssertionFailure(
             operator: "listen_with_handle",
             message: "Server failed to start on port 19990: "
+              <> string.inspect(start_error),
+            payload: None,
+          ))
+      }
+    }),
+    it("listen_with_handle fails when port is already in use", fn() {
+      // Arrange
+      let dream_instance =
+        server.new()
+        |> server.router(router())
+      let port = 19_996
+
+      // Act
+      let first_result = server.listen_with_handle(dream_instance, port)
+
+      // Assert
+      case first_result {
+        Ok(handle) -> {
+          let second_result = server.listen_with_handle(dream_instance, port)
+          server.stop(handle)
+
+          case second_result {
+            Error(actor.InitFailed(message)) -> {
+              case string.contains(message, "already in use") {
+                True -> AssertionOk
+                False ->
+                  AssertionFailed(AssertionFailure(
+                    operator: "listen_with_handle_port_in_use",
+                    message: "Expected clear port-in-use message, got: "
+                      <> message,
+                    payload: None,
+                  ))
+              }
+            }
+            Error(start_error) ->
+              AssertionFailed(AssertionFailure(
+                operator: "listen_with_handle_port_in_use",
+                message: "Unexpected start error: "
+                  <> string.inspect(start_error),
+                payload: None,
+              ))
+            Ok(_) ->
+              AssertionFailed(AssertionFailure(
+                operator: "listen_with_handle_port_in_use",
+                message: "Expected second server start to fail on same port",
+                payload: None,
+              ))
+          }
+        }
+        Error(start_error) ->
+          AssertionFailed(AssertionFailure(
+            operator: "listen_with_handle_port_in_use",
+            message: "Failed to start first server: "
               <> string.inspect(start_error),
             payload: None,
           ))


### PR DESCRIPTION
## Why
- Ship the 2.3.2 patch release with clearer startup failures and local test setup parity.
- Move the release artifacts from develop to main.

## What
- Port-in-use startup check and clearer errors.
- `setup-integration-dbs` Makefile target.
- Changelog and release notes for 2.3.2 (with reporter credit).

## How
- Introduced a small port probe helper and refactored server startup flow.
- Added a DB setup target that mirrors CI database prep.
- Bumped version and documented changes.