### PR TITLE
Release 2.3.2: Mock server config at startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
       - main
       - develop
 
+env:
+  OTP_VERSION: "28"
+  GLEAM_VERSION: "1.14.0"
+  REBAR3_VERSION: "3"
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
@@ -17,9 +22,9 @@ jobs:
       - name: Install Erlang and Gleam
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "28"
-          gleam-version: "1.13.0"
-          rebar3-version: "3"
+          otp-version: ${{ env.OTP_VERSION }}
+          gleam-version: ${{ env.GLEAM_VERSION }}
+          rebar3-version: ${{ env.REBAR3_VERSION }}
 
       - name: Download dependencies
         run: gleam deps download
@@ -82,9 +87,9 @@ jobs:
       - name: Install Erlang and Gleam
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "28"
-          gleam-version: "1.13.0"
-          rebar3-version: "3"
+          otp-version: ${{ env.OTP_VERSION }}
+          gleam-version: ${{ env.GLEAM_VERSION }}
+          rebar3-version: ${{ env.REBAR3_VERSION }}
           elixir-version: "1.18"
 
       - name: Download dependencies

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
 
+env:
+  OTP_VERSION: "28"
+  GLEAM_VERSION: "1.14.0"
+  REBAR3_VERSION: "3"
+
 jobs:
   publish-docs:
     name: Publish Documentation to Hex
@@ -71,9 +76,9 @@ jobs:
       - name: Install Erlang and Gleam
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "28"
-          gleam-version: "1.13.0"
-          rebar3-version: "3"
+          otp-version: ${{ env.OTP_VERSION }}
+          gleam-version: ${{ env.GLEAM_VERSION }}
+          rebar3-version: ${{ env.REBAR3_VERSION }}
 
       - name: Download dependencies
         run: gleam deps download

--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -11,6 +11,11 @@ on:
   workflow_dispatch:
     # Allows manual triggering for testing
 
+env:
+  OTP_VERSION: "28"
+  GLEAM_VERSION: "1.14.0"
+  REBAR3_VERSION: "3"
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
@@ -129,9 +134,9 @@ jobs:
         if: steps.version_check.outputs.should_publish == 'true'
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "28"
-          gleam-version: "1.13.0"
-          rebar3-version: "3"
+          otp-version: ${{ env.OTP_VERSION }}
+          gleam-version: ${{ env.GLEAM_VERSION }}
+          rebar3-version: ${{ env.REBAR3_VERSION }}
 
       - name: Download dependencies
         if: steps.version_check.outputs.should_publish == 'true'
@@ -225,9 +230,9 @@ jobs:
       - name: Install Erlang and Gleam
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "28"
-          gleam-version: "1.13.0"
-          rebar3-version: "3"
+          otp-version: ${{ env.OTP_VERSION }}
+          gleam-version: ${{ env.GLEAM_VERSION }}
+          rebar3-version: ${{ env.REBAR3_VERSION }}
 
       - name: Build and test module
         uses: ./.github/actions/test-module
@@ -272,9 +277,9 @@ jobs:
       - name: Install Erlang and Gleam
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "28"
-          gleam-version: "1.13.0"
-          rebar3-version: "3"
+          otp-version: ${{ env.OTP_VERSION }}
+          gleam-version: ${{ env.GLEAM_VERSION }}
+          rebar3-version: ${{ env.REBAR3_VERSION }}
 
       - name: Build and test module (with local Dream dependencies)
         uses: ./.github/actions/test-module

--- a/Makefile
+++ b/Makefile
@@ -86,4 +86,3 @@ setup-integration-dbs:
 	@cd examples/database && docker-compose exec -T postgres psql -U postgres -c "CREATE DATABASE dream_example_multi_format_db;" > /dev/null 2>&1
 	@cd examples/database && export DATABASE_URL=postgres://postgres:postgres@localhost:5435/dream_example_database_db && gleam run -m cigogne all
 	@cd examples/multi_format && export DATABASE_URL=postgres://postgres:postgres@localhost:5435/dream_example_multi_format_db && gleam run -m cigogne all
-

--- a/examples/streaming/manifest.toml
+++ b/examples/streaming/manifest.toml
@@ -2,10 +2,9 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "dream", version = "2.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "gleam_yielder", "marceau", "mist", "simplifile"], source = "local", path = "../.." },
-  { name = "dream_ets", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_stdlib"], source = "local", path = "../../modules/ets" },
-  { name = "dream_http_client", version = "2.1.0", build_tools = ["gleam"], requirements = ["dream_ets", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_yielder", "simplifile"], source = "local", path = "../../modules/http_client" },
-  { name = "dream_mock_server", version = "1.0.0", build_tools = ["gleam"], requirements = ["dream", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_yielder"], source = "local", path = "../../modules/mock_server" },
+  { name = "dream", version = "2.3.2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "gleam_yielder", "marceau", "mist", "simplifile"], source = "local", path = "../.." },
+  { name = "dream_http_client", version = "4.1.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_yielder", "simplifile"], source = "local", path = "../../modules/http_client" },
+  { name = "dream_mock_server", version = "1.1.0", build_tools = ["gleam"], requirements = ["dream", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_yielder"], source = "local", path = "../../modules/mock_server" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
@@ -13,16 +12,16 @@ packages = [
   { name = "gleam_http", version = "4.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "82EA6A717C842456188C190AFB372665EA56CE13D8559BF3B1DD9E40F619EE0C" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
-  { name = "gleam_stdlib", version = "0.67.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "6368313DB35963DC02F677A513BB0D95D58A34ED0A9436C8116820BF94BE3511" },
-  { name = "gleam_time", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "0DF3834D20193F0A38D0EB21F0A78D48F2EC276C285969131B86DF8D4EF9E762" },
+  { name = "gleam_stdlib", version = "0.69.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "AAB0962BEBFAA67A2FBEE9EEE218B057756808DC9AF77430F5182C6115B3A315" },
+  { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
-  { name = "glisten", version = "8.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "534BB27C71FB9E506345A767C0D76B17A9E9199934340C975DC003C710E3692D" },
+  { name = "glisten", version = "8.0.3", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "86B838196592D9EBDE7A1D2369AE3A51E568F7DD2D168706C463C42D17B95312" },
   { name = "gramps", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "8B7195978FBFD30B43DF791A8A272041B81E45D245314D7A41FC57237AA882A0" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
   { name = "logging", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "1098FBF10B54B44C2C7FDF0B01C1253CAFACDACABEFB4B0D027803246753E06D" },
   { name = "marceau", version = "1.3.0", build_tools = ["gleam"], requirements = [], otp_app = "marceau", source = "hex", outer_checksum = "2D1C27504BEF45005F5DFB18591F8610FB4BFA91744878210BDC464412EC44E9" },
-  { name = "mist", version = "5.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_yielder", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "7C4BE717A81305323C47C8A591E6B9BA4AC7F56354BF70B4D3DF08CC01192668" },
-  { name = "simplifile", version = "2.3.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "957E0E5B75927659F1D2A1B7B75D7B9BA96FAA8D0C53EA71C4AD9CD0C6B848F6" },
+  { name = "mist", version = "5.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_yielder", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "7CED4B2D81FD547ADB093D97B9928B9419A7F58B8562A30A6CC17A252B31AD05" },
+  { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
 ]
 
@@ -30,8 +29,8 @@ packages = [
 dream = { path = "../.." }
 dream_http_client = { path = "../../modules/http_client" }
 dream_mock_server = { path = "../../modules/mock_server" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.0.0 and < 5.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleam_yielder = { version = ">= 1.1.0 and < 2.0.0" }
 mist = { version = ">= 5.0.3 and < 6.0.0" }
-gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }

--- a/examples/streaming_capabilities/Makefile
+++ b/examples/streaming_capabilities/Makefile
@@ -55,4 +55,3 @@ test-integration:
 clean:
 	@gleam clean
 	@rm -f erl_crash.dump
-

--- a/examples/streaming_capabilities/manifest.toml
+++ b/examples/streaming_capabilities/manifest.toml
@@ -2,9 +2,9 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "dream", version = "2.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "gleam_yielder", "marceau", "mist", "simplifile"], source = "local", path = "../.." },
-  { name = "dream_http_client", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_yielder", "simplifile"], source = "local", path = "../../modules/http_client" },
-  { name = "dream_mock_server", version = "1.0.0", build_tools = ["gleam"], requirements = ["dream", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_yielder"], source = "local", path = "../../modules/mock_server" },
+  { name = "dream", version = "2.3.2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "gleam_yielder", "marceau", "mist", "simplifile"], source = "local", path = "../.." },
+  { name = "dream_http_client", version = "4.1.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_yielder", "simplifile"], source = "local", path = "../../modules/http_client" },
+  { name = "dream_mock_server", version = "1.1.0", build_tools = ["gleam"], requirements = ["dream", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_yielder"], source = "local", path = "../../modules/mock_server" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
@@ -12,16 +12,16 @@ packages = [
   { name = "gleam_http", version = "4.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "82EA6A717C842456188C190AFB372665EA56CE13D8559BF3B1DD9E40F619EE0C" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
-  { name = "gleam_stdlib", version = "0.67.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "6368313DB35963DC02F677A513BB0D95D58A34ED0A9436C8116820BF94BE3511" },
-  { name = "gleam_time", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "0DF3834D20193F0A38D0EB21F0A78D48F2EC276C285969131B86DF8D4EF9E762" },
+  { name = "gleam_stdlib", version = "0.69.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "AAB0962BEBFAA67A2FBEE9EEE218B057756808DC9AF77430F5182C6115B3A315" },
+  { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
-  { name = "glisten", version = "8.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "534BB27C71FB9E506345A767C0D76B17A9E9199934340C975DC003C710E3692D" },
+  { name = "glisten", version = "8.0.3", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "86B838196592D9EBDE7A1D2369AE3A51E568F7DD2D168706C463C42D17B95312" },
   { name = "gramps", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "8B7195978FBFD30B43DF791A8A272041B81E45D245314D7A41FC57237AA882A0" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
   { name = "logging", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "1098FBF10B54B44C2C7FDF0B01C1253CAFACDACABEFB4B0D027803246753E06D" },
   { name = "marceau", version = "1.3.0", build_tools = ["gleam"], requirements = [], otp_app = "marceau", source = "hex", outer_checksum = "2D1C27504BEF45005F5DFB18591F8610FB4BFA91744878210BDC464412EC44E9" },
-  { name = "mist", version = "5.0.3", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_yielder", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "7C4BE717A81305323C47C8A591E6B9BA4AC7F56354BF70B4D3DF08CC01192668" },
-  { name = "simplifile", version = "2.3.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "957E0E5B75927659F1D2A1B7B75D7B9BA96FAA8D0C53EA71C4AD9CD0C6B848F6" },
+  { name = "mist", version = "5.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_yielder", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "7CED4B2D81FD547ADB093D97B9928B9419A7F58B8562A30A6CC17A252B31AD05" },
+  { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
 ]
 
@@ -29,7 +29,7 @@ packages = [
 dream = { path = "../../" }
 dream_http_client = { path = "../../modules/http_client" }
 dream_mock_server = { path = "../../modules/mock_server" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
 gleam_http = { version = ">= 3.6.0" }
 gleam_stdlib = { version = ">= 0.34.0" }
 gleam_yielder = { version = ">= 0.3.0" }
-gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }

--- a/modules/mock_server/CHANGELOG.md
+++ b/modules/mock_server/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `dream_mock_server` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## 1.1.0 - 2026-02-15
+
+### Added
+
+- **Config mode:** `start_with_config(port, config)` starts the mock with a caller-provided list of routes (path, optional method, status, body). No built-in provider logic; first matching route wins; no match returns 404. Use for proxy tests or any deterministic upstream. New types: `dream_mock_server/config.{MockRoute, PathMatch, Exact, Prefix}`.
+
 ## 1.0.0 - 2025-11-24
 
 ### Added

--- a/modules/mock_server/README.md
+++ b/modules/mock_server/README.md
@@ -2,6 +2,8 @@
 
 A general-purpose HTTP mock server developed by Dream that provides both streaming and non-streaming endpoints for testing HTTP clients.
 
+**Current module version:** `1.1.0`
+
 ## Overview
 
 This module provides a comprehensive set of endpoints for testing HTTP clients:
@@ -43,6 +45,78 @@ pub fn my_test() {
   server.stop(handle)
 }
 ```
+<sub>🧪 [Tested source](test/snippets/programmatic_mode.gleam)</sub>
+
+### Config mode
+
+For proxy tests or any test that needs a **deterministic upstream** with specific status and body per path, start the server with a config list. The mock has no built-in provider logic (no OpenAI, Google, AWS, etc.); the caller supplies all path → (status, body) mappings. First matching route in the list wins.
+
+```gleam
+import dream_mock_server/config.{MockRoute, Prefix}
+import dream_mock_server/server
+import gleam/option.{None}
+
+// One route: path /v1/chat/completions (prefix match), any method, 200 + JSON body
+let config = [
+  MockRoute(
+    path: "/v1/chat/completions",
+    path_match: Prefix,
+    method: None,
+    status: 200,
+    body: "{\"choices\":[{\"message\":{\"content\":\"\"}}]}",
+  ),
+]
+let assert Ok(handle) = server.start_with_config(3004, config)
+// Point your proxy or client at http://127.0.0.1:3004 ...
+server.stop(handle)
+```
+<sub>🧪 [Tested source](test/snippets/config_mode_prefix.gleam)</sub>
+
+#### How matching works
+
+- Matching is **first route wins** in list order.
+- `Exact` means request path must equal `path`.
+- `Prefix` means request path must start with `path`.
+- `method: Some(Get)` (or Post/Put/Delete/Patch) restricts by method.
+- `method: None` matches any method.
+- No match returns `404` with body `"Not found"`.
+
+#### Exact + method-specific example
+
+```gleam
+import dream/http/request.{Get, Post}
+import dream_mock_server/config.{Exact, MockRoute}
+import dream_mock_server/server
+import gleam/option.{Some}
+
+let config = [
+  MockRoute("/resource", Exact, Some(Get), 200, "{\"ok\":true}"),
+  MockRoute("/resource", Exact, Some(Post), 201, "{\"created\":true}"),
+]
+let assert Ok(handle) = server.start_with_config(3004, config)
+// GET /resource  -> 200 {"ok":true}
+// POST /resource -> 201 {"created":true}
+server.stop(handle)
+```
+<sub>🧪 [Tested source](test/snippets/config_mode_method_specific.gleam)</sub>
+
+#### Ordering gotcha (important)
+
+If you mix broad prefixes and specific routes, put specific routes first:
+
+```gleam
+// Good: specific before broad prefix
+[
+  MockRoute("/api/special", Exact, None, 200, "special"),
+  MockRoute("/api", Prefix, None, 200, "general"),
+]
+```
+<sub>🧪 [Tested source](test/snippets/config_mode_ordering.gleam)</sub>
+
+- **Path match:** `Exact` (path must equal) or `Prefix` (path must start with).
+- **Method:** `Some(Get)` etc. to restrict; `None` for any method.
+- **Order:** Put more specific routes before broader prefix routes so they match first.
+- **No match:** Returns 404 with body `"Not found"`.
 
 ## Non-Streaming Endpoints
 
@@ -333,6 +407,18 @@ src/
 - **gleam_erlang** - Process control (sleep)
 - **gleam_json** - JSON encoding
 - **gleam_yielder** - Stream generation
+
+## All Examples Are Tested
+
+The core usage examples in this README are backed by runnable snippet tests
+under `test/snippets/` and executed by `test/snippets_test.gleam`.
+
+Run them with:
+
+```bash
+cd modules/mock_server
+gleam test
+```
 
 ## See Also
 

--- a/modules/mock_server/gleam.toml
+++ b/modules/mock_server/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream_mock_server"
-version = "1.0.0"
+version = "1.1.0"
 description = "General-purpose HTTP mock server developed by Dream - provides both streaming and non-streaming endpoints for testing HTTP clients"
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }

--- a/modules/mock_server/releases/release-1.1.0.md
+++ b/modules/mock_server/releases/release-1.1.0.md
@@ -1,0 +1,97 @@
+# Dream Mock Server Release 1.1.0: Startup Config for Deterministic Tests
+
+**Release Date:** February 15, 2026
+
+This release adds a config-driven startup mode so test suites can define exact
+upstream responses without embedding provider-specific behavior in the mock.
+
+## Why this release exists
+
+Proxy/adaptor tests often need deterministic upstream behavior:
+
+- match a specific path (or path prefix),
+- optionally enforce a specific HTTP method,
+- and return a known status/body pair.
+
+Before this release, `dream_mock_server` mainly exposed built-in demo/testing
+endpoints. That was useful, but not expressive enough for endpoint-specific
+proxy assertions where tests must control payload shape and status codes.
+
+## What was added
+
+### New startup API
+
+- `server.start_with_config(port, config)`
+
+Starts the mock using only caller-provided routes. Built-in endpoints are not
+used in this mode.
+
+### New config module and types
+
+- `dream_mock_server/config`
+  - `PathMatch` (`Exact`, `Prefix`)
+  - `MockRoute(path, path_match, method, status, body)`
+  - `MockConfigContext(routes)` (internal context for config mode)
+
+### Matching behavior
+
+- Routes are evaluated in list order.
+- First matching route wins.
+- Match conditions:
+  - Path matches (`Exact` or `Prefix`)
+  - Method matches (`Some(method)`) or route method is `None`
+- No match => `404` with body `"Not found"`.
+
+## Backward compatibility
+
+- `server.start(port)` is unchanged and still serves existing built-in endpoints.
+- `start_with_config` is additive and backward-compatible.
+
+## How to use it
+
+```gleam
+import dream_mock_server/config.{MockRoute, Prefix}
+import dream_mock_server/server
+import gleam/option.{None}
+
+let config = [
+  MockRoute(
+    path: "/v1/chat/completions",
+    path_match: Prefix,
+    method: None,
+    status: 200,
+    body: "{\"choices\":[{\"message\":{\"content\":\"\"}}]}",
+  ),
+]
+
+let assert Ok(handle) = server.start_with_config(3004, config)
+// ... run tests against http://127.0.0.1:3004 ...
+server.stop(handle)
+```
+
+## Test coverage added
+
+Config mode includes dedicated tests for:
+
+- exact and prefix path matching,
+- first-match ordering behavior,
+- optional vs method-specific routes,
+- non-200 statuses and custom bodies,
+- no-match 404 behavior,
+- start/stop/restart lifecycle behavior.
+
+## Upgrade notes
+
+Update dependency constraints:
+
+```toml
+[dependencies]
+dream_mock_server = ">= 1.1.0 and < 2.0.0"
+```
+
+Then:
+
+```bash
+gleam deps download
+```
+

--- a/modules/mock_server/src/dream_mock_server/config.gleam
+++ b/modules/mock_server/src/dream_mock_server/config.gleam
@@ -1,0 +1,52 @@
+//// # Mock server config types
+////
+//// Types for configuring the mock server at startup when using config mode.
+//// Pass a list of `MockRoute` to `server.start_with_config(port, config)` to define
+//// path → (status, body) mappings. The mock has no built-in provider logic;
+//// the caller supplies all routes.
+
+import dream/http/request.{type Method}
+import gleam/option
+
+/// How to match the request path against a route's path.
+///
+/// Use `Exact` when you want one concrete path, and `Prefix` when a route
+/// should cover a path family (for example `/api` matching `/api/v1/users`).
+pub type PathMatch {
+  /// Request path must equal the route path exactly.
+  Exact
+  /// Request path must start with the route path (e.g. "/api" matches "/api/v1").
+  Prefix
+}
+
+/// One response rule used by `server.start_with_config`.
+///
+/// When a request matches this route's path (and optional method), the mock
+/// returns the configured status and body exactly as provided.
+///
+/// First matching entry in the config list wins. Put more specific routes before
+/// broader prefix routes if you want them to take precedence.
+///
+/// ## Fields
+///
+/// - `path`: Path to match, such as `"/v1/chat/completions"`.
+/// - `path_match`: `Exact` or `Prefix`.
+/// - `method`: `Some(Method)` to restrict by method, or `None` to match any.
+/// - `status`: HTTP status code to return.
+/// - `body`: Response body string to return (JSON, text, or any payload).
+pub type MockRoute {
+  MockRoute(
+    path: String,
+    path_match: PathMatch,
+    method: option.Option(Method),
+    status: Int,
+    body: String,
+  )
+}
+
+/// Context used internally when the server is started in config mode.
+///
+/// It holds the route list consumed by the config router/controller.
+pub type MockConfigContext {
+  MockConfigContext(routes: List(MockRoute))
+}

--- a/modules/mock_server/src/dream_mock_server/controllers/config_controller.gleam
+++ b/modules/mock_server/src/dream_mock_server/controllers/config_controller.gleam
@@ -1,0 +1,63 @@
+//// config_controller.gleam - Config-mode request handler
+////
+//// When the mock server is started with a config list, all requests are
+//// handled by this controller. It looks up the first matching route by path
+//// (exact or prefix) and optional method, and returns that route's status and body.
+//// If no route matches, returns 404.
+
+import dream/http/request.{type Request}
+import dream/http/response.{type Response, text_response}
+import dream/router.{type EmptyServices}
+import dream_mock_server/config.{
+  type MockConfigContext, type MockRoute, type PathMatch, Exact, Prefix,
+}
+import gleam/option
+import gleam/string
+
+/// Handle a request by finding the first matching route in the config.
+/// First match wins (list order). No match returns 404.
+pub fn handle(
+  request: Request,
+  context: MockConfigContext,
+  _services: EmptyServices,
+) -> Response {
+  case find_match(request, context.routes) {
+    option.Some(route) -> text_response(route.status, route.body)
+    option.None -> text_response(404, "Not found")
+  }
+}
+
+fn find_match(
+  request: Request,
+  routes: List(MockRoute),
+) -> option.Option(MockRoute) {
+  case routes {
+    [] -> option.None
+    [route, ..rest] -> {
+      case route_matches(request, route) {
+        True -> option.Some(route)
+        False -> find_match(request, rest)
+      }
+    }
+  }
+}
+
+fn route_matches(request: Request, route: MockRoute) -> Bool {
+  let path_ok = path_matches(request.path, route.path, route.path_match)
+  let method_ok = case route.method {
+    option.None -> True
+    option.Some(m) -> request.method == m
+  }
+  path_ok && method_ok
+}
+
+fn path_matches(
+  request_path: String,
+  route_path: String,
+  path_match: PathMatch,
+) -> Bool {
+  case path_match {
+    Exact -> request_path == route_path
+    Prefix -> string.starts_with(request_path, route_path)
+  }
+}

--- a/modules/mock_server/src/dream_mock_server/router.gleam
+++ b/modules/mock_server/src/dream_mock_server/router.gleam
@@ -29,9 +29,11 @@
 //// - `GET /stream/binary` - Binary data stream
 
 import dream/context.{type EmptyContext}
-import dream/http/request.{Delete, Get, Post, Put}
+import dream/http/request.{Delete, Get, Patch, Post, Put}
 import dream/router.{type EmptyServices, type Router, route, router}
+import dream_mock_server/config.{type MockConfigContext}
 import dream_mock_server/controllers/api_controller
+import dream_mock_server/controllers/config_controller
 import dream_mock_server/controllers/stream_controller
 
 /// Create a router with all mock endpoints (streaming and non-streaming)
@@ -161,6 +163,46 @@ pub fn create_router() -> Router(EmptyContext, EmptyServices) {
     method: Get,
     path: "/stream/binary",
     controller: stream_controller.stream_binary,
+    middleware: [],
+  )
+}
+
+/// Create a router for config mode: a single catch-all route per method
+/// that delegates to the config controller. Used when starting with
+/// `server.start_with_config(port, config)`.
+///
+/// This router intentionally contains no built-in demo endpoints. All response
+/// behavior comes from the caller-provided `MockRoute` list held in context.
+pub fn create_config_router() -> Router(MockConfigContext, EmptyServices) {
+  router()
+  |> route(
+    method: Get,
+    path: "/**path",
+    controller: config_controller.handle,
+    middleware: [],
+  )
+  |> route(
+    method: Post,
+    path: "/**path",
+    controller: config_controller.handle,
+    middleware: [],
+  )
+  |> route(
+    method: Put,
+    path: "/**path",
+    controller: config_controller.handle,
+    middleware: [],
+  )
+  |> route(
+    method: Delete,
+    path: "/**path",
+    controller: config_controller.handle,
+    middleware: [],
+  )
+  |> route(
+    method: Patch,
+    path: "/**path",
+    controller: config_controller.handle,
     middleware: [],
   )
 }

--- a/modules/mock_server/src/dream_mock_server/server.gleam
+++ b/modules/mock_server/src/dream_mock_server/server.gleam
@@ -50,8 +50,9 @@
 //// - `GET /stream/json` - JSON object stream
 //// - `GET /stream/binary` - Binary data stream
 
-import dream/servers/mist/server.{bind, listen_with_handle, router} as dream_server
-import dream_mock_server/router.{create_router}
+import dream/servers/mist/server.{bind, context, listen_with_handle, router} as dream_server
+import dream_mock_server/config.{type MockRoute, MockConfigContext}
+import dream_mock_server/router.{create_config_router, create_router}
 import gleam/otp/actor
 
 /// Start the mock server on a specific port
@@ -86,6 +87,53 @@ import gleam/otp/actor
 pub fn start(port: Int) -> Result(dream_server.ServerHandle, actor.StartError) {
   dream_server.new()
   |> router(create_router())
+  |> bind("localhost")
+  |> listen_with_handle(port)
+}
+
+/// Start the mock server with caller-provided routes.
+///
+/// In this mode, the server uses only the supplied config list and does not
+/// expose the built-in demo endpoints from `start(port)`.
+///
+/// ## Matching semantics
+///
+/// - Routes are evaluated in list order.
+/// - First matching route wins.
+/// - A route matches when both are true:
+///   - Path matches according to `path_match` (`Exact` or `Prefix`)
+///   - Method matches (`Some(method)`) or the route method is `None`
+/// - If no route matches, response is `404` with body `"Not found"`.
+///
+/// Returns a `ServerHandle` that can be used to stop the server later.
+///
+/// ## Example
+///
+/// ```gleam
+/// import dream_mock_server/config.{MockRoute, Prefix}
+/// import dream_mock_server/server
+/// import gleam/option.{None}
+///
+/// let config = [
+///   MockRoute("/v1/chat/completions", Prefix, None, 200, "{\"ok\":true}"),
+/// ]
+/// let assert Ok(handle) = server.start_with_config(3004, config)
+/// // ... make requests to localhost:3004 ...
+/// server.stop(handle)
+/// ```
+///
+/// ## Typical use cases
+///
+/// - Deterministic proxy/adaptor tests
+/// - Verifying status and payload handling branches
+/// - Simulating external API behavior without provider-specific stubs
+pub fn start_with_config(
+  port: Int,
+  config: List(MockRoute),
+) -> Result(dream_server.ServerHandle, actor.StartError) {
+  dream_server.new()
+  |> context(MockConfigContext(routes: config))
+  |> router(create_config_router())
   |> bind("localhost")
   |> listen_with_handle(port)
 }

--- a/modules/mock_server/test/config_mode_test.gleam
+++ b/modules/mock_server/test/config_mode_test.gleam
@@ -1,0 +1,467 @@
+//// Comprehensive tests for mock server config mode (start_with_config).
+//// Covers path matching (exact, prefix, first-match order), method filtering,
+//// status/body, no-match 404, empty config, and lifecycle.
+
+import dream/http/request.{Get, Post}
+import dream_mock_server/config.{Exact, MockRoute, Prefix}
+import dream_mock_server/server
+import gleam/bit_array
+import gleam/erlang/process
+import gleam/int
+import gleam/option
+import gleam/result
+import gleeunit/should
+
+// Port range for config-mode tests (avoid clashing with server_test 19876+)
+fn config_test_port(base: Int) -> Int {
+  19_890 + base
+}
+
+@external(erlang, "http_test_ffi", "make_request_full")
+fn make_request_full(url: String) -> Result(#(Int, BitArray), BitArray)
+
+@external(erlang, "http_test_ffi", "make_request_with_method")
+fn make_request_with_method(
+  url: String,
+  method: String,
+  body: String,
+) -> Result(#(Int, BitArray), BitArray)
+
+fn bits_to_string(bits: BitArray) -> String {
+  bit_array.to_string(bits) |> result.unwrap("")
+}
+
+fn get(url: String) -> Result(#(Int, String), String) {
+  case make_request_full(url) {
+    Ok(#(status, body_bits)) -> Ok(#(status, bits_to_string(body_bits)))
+    Error(err_bits) -> Error(bits_to_string(err_bits))
+  }
+}
+
+fn post(url: String, body: String) -> Result(#(Int, String), String) {
+  case make_request_with_method(url, "POST", body) {
+    Ok(#(status, body_bits)) -> Ok(#(status, bits_to_string(body_bits)))
+    Error(err_bits) -> Error(bits_to_string(err_bits))
+  }
+}
+
+fn url(port: Int, path: String) -> String {
+  "http://localhost:" <> int.to_string(port) <> path
+}
+
+// ----- Path matching -----
+
+pub fn exact_match_returns_configured_response_test() {
+  let port = config_test_port(0)
+  let config = [
+    MockRoute("/foo", Exact, option.None, 200, "exact-foo"),
+  ]
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r = get(url(port, "/foo"))
+  server.stop(handle)
+  process.sleep(500)
+
+  case r {
+    Ok(#(status, body)) -> {
+      should.equal(status, 200)
+      should.equal(body, "exact-foo")
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+pub fn exact_match_subpath_returns_404_test() {
+  let port = config_test_port(1)
+  let config = [
+    MockRoute("/foo", Exact, option.None, 200, "ok"),
+  ]
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r = get(url(port, "/foo/bar"))
+  server.stop(handle)
+  process.sleep(500)
+
+  case r {
+    Ok(#(status, body)) -> {
+      should.equal(status, 404)
+      should.equal(body, "Not found")
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+pub fn prefix_match_returns_configured_response_test() {
+  let port = config_test_port(2)
+  let config = [
+    MockRoute("/api", Prefix, option.None, 200, "api"),
+  ]
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r1 = get(url(port, "/api"))
+  let r2 = get(url(port, "/api/v1"))
+  let r3 = get(url(port, "/api/v1/chat"))
+  server.stop(handle)
+  process.sleep(500)
+
+  case r1 {
+    Ok(#(s, b)) -> {
+      should.equal(s, 200)
+      should.equal(b, "api")
+    }
+    Error(_e) -> should.fail()
+  }
+  case r2 {
+    Ok(#(s, b)) -> {
+      should.equal(s, 200)
+      should.equal(b, "api")
+    }
+    Error(_e) -> should.fail()
+  }
+  case r3 {
+    Ok(#(s, b)) -> {
+      should.equal(s, 200)
+      should.equal(b, "api")
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+pub fn prefix_no_match_returns_404_test() {
+  let port = config_test_port(3)
+  let config = [
+    MockRoute("/api", Prefix, option.None, 200, "api"),
+  ]
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r1 = get(url(port, "/ap"))
+  let r2 = get(url(port, "/other"))
+  server.stop(handle)
+  process.sleep(500)
+
+  case r1 {
+    Ok(#(s, b)) -> {
+      should.equal(s, 404)
+      should.equal(b, "Not found")
+    }
+    Error(_e) -> should.fail()
+  }
+  case r2 {
+    Ok(#(s, b)) -> {
+      should.equal(s, 404)
+      should.equal(b, "Not found")
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+pub fn first_match_wins_order_test() {
+  let port = config_test_port(4)
+  // More specific first: /api/special exact, then /api prefix.
+  let config = [
+    MockRoute("/api/special", Exact, option.None, 200, "special"),
+    MockRoute("/api", Prefix, option.None, 200, "api"),
+  ]
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r_special = get(url(port, "/api/special"))
+  let r_api = get(url(port, "/api"))
+  let r_api_other = get(url(port, "/api/other"))
+  server.stop(handle)
+  process.sleep(500)
+
+  case r_special {
+    Ok(#(s, b)) -> {
+      should.equal(s, 200)
+      should.equal(b, "special")
+    }
+    Error(_e) -> should.fail()
+  }
+  case r_api {
+    Ok(#(s, b)) -> {
+      should.equal(s, 200)
+      should.equal(b, "api")
+    }
+    Error(_e) -> should.fail()
+  }
+  case r_api_other {
+    Ok(#(s, b)) -> {
+      should.equal(s, 200)
+      should.equal(b, "api")
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+// ----- Method filtering -----
+
+pub fn optional_method_any_method_matches_test() {
+  let port = config_test_port(5)
+  let config = [
+    MockRoute("/any", Exact, option.None, 200, "ok"),
+  ]
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r_get = get(url(port, "/any"))
+  let r_post = post(url(port, "/any"), "")
+  server.stop(handle)
+  process.sleep(500)
+
+  case r_get {
+    Ok(#(s, b)) -> {
+      should.equal(s, 200)
+      should.equal(b, "ok")
+    }
+    Error(_e) -> should.fail()
+  }
+  case r_post {
+    Ok(#(s, b)) -> {
+      should.equal(s, 200)
+      should.equal(b, "ok")
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+pub fn specific_method_only_post_matches_test() {
+  let port = config_test_port(6)
+  let config = [
+    MockRoute("/post-only", Exact, option.Some(Post), 201, "created"),
+  ]
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r_post = post(url(port, "/post-only"), "")
+  let r_get = get(url(port, "/post-only"))
+  server.stop(handle)
+  process.sleep(500)
+
+  case r_post {
+    Ok(#(s, b)) -> {
+      should.equal(s, 201)
+      should.equal(b, "created")
+    }
+    Error(_e) -> should.fail()
+  }
+  case r_get {
+    Ok(#(s, b)) -> {
+      should.equal(s, 404)
+      should.equal(b, "Not found")
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+pub fn multiple_methods_same_path_test() {
+  let port = config_test_port(7)
+  let config = [
+    MockRoute("/r", Exact, option.Some(Get), 200, "get"),
+    MockRoute("/r", Exact, option.Some(Post), 201, "post"),
+  ]
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r_get = get(url(port, "/r"))
+  let r_post = post(url(port, "/r"), "")
+  server.stop(handle)
+  process.sleep(500)
+
+  case r_get {
+    Ok(#(s, b)) -> {
+      should.equal(s, 200)
+      should.equal(b, "get")
+    }
+    Error(_e) -> should.fail()
+  }
+  case r_post {
+    Ok(#(s, b)) -> {
+      should.equal(s, 201)
+      should.equal(b, "post")
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+// ----- Status and body -----
+
+pub fn non_200_status_returned_test() {
+  let port = config_test_port(8)
+  let config = [
+    MockRoute("/created", Exact, option.None, 201, "created"),
+    MockRoute("/error", Exact, option.None, 500, "server error"),
+  ]
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r1 = get(url(port, "/created"))
+  let r2 = get(url(port, "/error"))
+  server.stop(handle)
+  process.sleep(500)
+
+  case r1 {
+    Ok(#(s, b)) -> {
+      should.equal(s, 201)
+      should.equal(b, "created")
+    }
+    Error(_e) -> should.fail()
+  }
+  case r2 {
+    Ok(#(s, b)) -> {
+      should.equal(s, 500)
+      should.equal(b, "server error")
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+pub fn empty_body_returned_test() {
+  let port = config_test_port(9)
+  let config = [
+    MockRoute("/empty", Exact, option.None, 200, ""),
+  ]
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r = get(url(port, "/empty"))
+  server.stop(handle)
+  process.sleep(500)
+
+  case r {
+    Ok(#(status, body)) -> {
+      should.equal(status, 200)
+      should.equal(body, "")
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+pub fn json_body_returned_verbatim_test() {
+  let port = config_test_port(10)
+  let body = "{\"key\":\"value\"}"
+  let config = [
+    MockRoute("/json", Exact, option.None, 200, body),
+  ]
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r = get(url(port, "/json"))
+  server.stop(handle)
+  process.sleep(500)
+
+  case r {
+    Ok(#(status, res_body)) -> {
+      should.equal(status, 200)
+      should.equal(res_body, body)
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+// ----- No match and edge cases -----
+
+pub fn no_matching_path_returns_404_test() {
+  let port = config_test_port(11)
+  let config = [
+    MockRoute("/a", Exact, option.None, 200, "a"),
+    MockRoute("/b", Exact, option.None, 200, "b"),
+  ]
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r1 = get(url(port, "/c"))
+  let r2 = get(url(port, "/"))
+  server.stop(handle)
+  process.sleep(500)
+
+  case r1 {
+    Ok(#(s, b)) -> {
+      should.equal(s, 404)
+      should.equal(b, "Not found")
+    }
+    Error(_e) -> should.fail()
+  }
+  case r2 {
+    Ok(#(s, b)) -> {
+      should.equal(s, 404)
+      should.equal(b, "Not found")
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+pub fn path_matches_method_does_not_returns_404_test() {
+  let port = config_test_port(12)
+  let config = [
+    MockRoute("/r", Exact, option.Some(Post), 200, "post"),
+  ]
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r = get(url(port, "/r"))
+  server.stop(handle)
+  process.sleep(500)
+
+  case r {
+    Ok(#(s, b)) -> {
+      should.equal(s, 404)
+      should.equal(b, "Not found")
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+pub fn empty_config_every_request_404_test() {
+  let port = config_test_port(13)
+  let config = []
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let r = get(url(port, "/anything"))
+  server.stop(handle)
+  process.sleep(500)
+
+  case r {
+    Ok(#(s, b)) -> {
+      should.equal(s, 404)
+      should.equal(b, "Not found")
+    }
+    Error(_e) -> should.fail()
+  }
+}
+
+// ----- Lifecycle -----
+
+pub fn start_then_stop_then_restart_same_port_test() {
+  let port = config_test_port(14)
+  let config = [MockRoute("/x", Exact, option.None, 200, "x")]
+
+  let assert Ok(handle1) = server.start_with_config(port, config)
+  process.sleep(200)
+  server.stop(handle1)
+  process.sleep(500)
+
+  let result2 = server.start_with_config(port, config)
+  case result2 {
+    Ok(handle2) -> {
+      process.sleep(200)
+      let r = get(url(port, "/x"))
+      server.stop(handle2)
+      process.sleep(500)
+      case r {
+        Ok(#(s, b)) -> {
+          should.equal(s, 200)
+          should.equal(b, "x")
+        }
+        Error(_e) -> should.fail()
+      }
+    }
+    Error(_) -> Nil
+  }
+  should.be_ok(result2)
+}

--- a/modules/mock_server/test/http_test_ffi.erl
+++ b/modules/mock_server/test/http_test_ffi.erl
@@ -1,5 +1,5 @@
 -module(http_test_ffi).
--export([make_request/1]).
+-export([make_request/1, make_request_full/1, make_request_with_method/3]).
 
 %% Simple HTTP GET request using httpc
 %% Returns {ok, Body} or {error, Reason}
@@ -22,4 +22,38 @@ make_request(Url) when is_binary(Url) ->
         {error, Reason} ->
             {error, list_to_binary(io_lib:format("~p", [Reason]))}
     end.
+
+%% GET request returning {ok, {StatusCode, Body}} or {error, Reason} (for config-mode tests).
+make_request_full(Url) when is_binary(Url) ->
+    inets:start(),
+    UrlStr = binary_to_list(Url),
+    case httpc:request(get, {UrlStr, []}, [{timeout, 5000}], []) of
+        {ok, {{_Version, StatusCode, _ReasonPhrase}, _Headers, Body}} ->
+            {ok, {StatusCode, list_to_binary(ensure_string(Body))}};
+        {error, Reason} ->
+            {error, list_to_binary(io_lib:format("~p", [Reason]))}
+    end.
+
+%% Request with method and body; returns {ok, {StatusCode, Body}} or {error, Reason}.
+make_request_with_method(Url, Method, Body) when is_binary(Url), is_binary(Method), is_binary(Body) ->
+    inets:start(),
+    UrlStr = binary_to_list(Url),
+    MethodAtom = method_to_atom(binary_to_list(Method)),
+    BodyStr = binary_to_list(Body),
+    Request = {UrlStr, [], "application/octet-stream", BodyStr},
+    case httpc:request(MethodAtom, Request, [{timeout, 5000}], []) of
+        {ok, {{_Version, StatusCode, _ReasonPhrase}, _Headers, RespBody}} ->
+            {ok, {StatusCode, list_to_binary(ensure_string(RespBody))}};
+        {error, Reason} ->
+            {error, list_to_binary(io_lib:format("~p", [Reason]))}
+    end.
+
+ensure_string(Body) when is_list(Body) -> Body;
+ensure_string(Body) when is_binary(Body) -> binary_to_list(Body).
+
+method_to_atom("GET") -> get;
+method_to_atom("POST") -> post;
+method_to_atom("PUT") -> put;
+method_to_atom("DELETE") -> delete;
+method_to_atom("PATCH") -> patch.
 

--- a/modules/mock_server/test/snippets/config_mode_method_specific.gleam
+++ b/modules/mock_server/test/snippets/config_mode_method_specific.gleam
@@ -1,0 +1,32 @@
+//// Exact + method-specific snippet from README.
+
+import dream/http/request.{Get, Post}
+import dream_mock_server/config.{Exact, MockRoute}
+import dream_mock_server/server
+import gleam/erlang/process
+import gleam/int
+import gleam/option.{Some}
+import snippets/http_helper
+
+pub fn run() -> Result(Bool, String) {
+  let port = 19_922
+  let config = [
+    MockRoute("/resource", Exact, Some(Get), 200, "{\"ok\":true}"),
+    MockRoute("/resource", Exact, Some(Post), 201, "{\"created\":true}"),
+  ]
+
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let url = "http://localhost:" <> int.to_string(port) <> "/resource"
+  let get_result = http_helper.get(url)
+  let post_result = http_helper.post(url, "")
+
+  server.stop(handle)
+  process.sleep(200)
+
+  case get_result, post_result {
+    Ok(#(200, "{\"ok\":true}")), Ok(#(201, "{\"created\":true}")) -> Ok(True)
+    _, _ -> Error("Method-specific routing did not match expected responses")
+  }
+}

--- a/modules/mock_server/test/snippets/config_mode_ordering.gleam
+++ b/modules/mock_server/test/snippets/config_mode_ordering.gleam
@@ -1,0 +1,31 @@
+//// Ordering gotcha snippet from README.
+
+import dream_mock_server/config.{Exact, MockRoute, Prefix}
+import dream_mock_server/server
+import gleam/erlang/process
+import gleam/int
+import gleam/option
+import snippets/http_helper
+
+pub fn run() -> Result(Bool, String) {
+  let port = 19_923
+  let config = [
+    MockRoute("/api/special", Exact, option.None, 200, "special"),
+    MockRoute("/api", Prefix, option.None, 200, "general"),
+  ]
+
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let base = "http://localhost:" <> int.to_string(port)
+  let special = http_helper.get(base <> "/api/special")
+  let general = http_helper.get(base <> "/api/other")
+
+  server.stop(handle)
+  process.sleep(200)
+
+  case special, general {
+    Ok(#(200, "special")), Ok(#(200, "general")) -> Ok(True)
+    _, _ -> Error("Route ordering did not produce expected matches")
+  }
+}

--- a/modules/mock_server/test/snippets/config_mode_prefix.gleam
+++ b/modules/mock_server/test/snippets/config_mode_prefix.gleam
@@ -1,0 +1,37 @@
+//// Config mode snippet (prefix + any method) from README.
+
+import dream_mock_server/config.{MockRoute, Prefix}
+import dream_mock_server/server
+import gleam/erlang/process
+import gleam/int
+import gleam/option
+import snippets/http_helper
+
+pub fn run() -> Result(Bool, String) {
+  let port = 19_921
+  let config = [
+    MockRoute(
+      path: "/v1/chat/completions",
+      path_match: Prefix,
+      method: option.None,
+      status: 200,
+      body: "{\"choices\":[{\"message\":{\"content\":\"\"}}]}",
+    ),
+  ]
+
+  let assert Ok(handle) = server.start_with_config(port, config)
+  process.sleep(200)
+
+  let url = "http://localhost:" <> int.to_string(port) <> "/v1/chat/completions"
+  let result = http_helper.get(url)
+
+  server.stop(handle)
+  process.sleep(200)
+
+  case result {
+    Ok(#(200, body)) ->
+      Ok(body == "{\"choices\":[{\"message\":{\"content\":\"\"}}]}")
+    Ok(_) -> Error("Unexpected status")
+    Error(e) -> Error(e)
+  }
+}

--- a/modules/mock_server/test/snippets/http_helper.gleam
+++ b/modules/mock_server/test/snippets/http_helper.gleam
@@ -1,0 +1,32 @@
+//// Shared HTTP helpers for documentation snippets.
+
+import gleam/bit_array
+import gleam/result
+
+@external(erlang, "http_test_ffi", "make_request_full")
+fn make_request_full(url: String) -> Result(#(Int, BitArray), BitArray)
+
+@external(erlang, "http_test_ffi", "make_request_with_method")
+fn make_request_with_method(
+  url: String,
+  method: String,
+  body: String,
+) -> Result(#(Int, BitArray), BitArray)
+
+fn bits_to_string(bits: BitArray) -> String {
+  bit_array.to_string(bits) |> result.unwrap("")
+}
+
+pub fn get(url: String) -> Result(#(Int, String), String) {
+  case make_request_full(url) {
+    Ok(#(status, body_bits)) -> Ok(#(status, bits_to_string(body_bits)))
+    Error(err_bits) -> Error(bits_to_string(err_bits))
+  }
+}
+
+pub fn post(url: String, body: String) -> Result(#(Int, String), String) {
+  case make_request_with_method(url, "POST", body) {
+    Ok(#(status, body_bits)) -> Ok(#(status, bits_to_string(body_bits)))
+    Error(err_bits) -> Error(bits_to_string(err_bits))
+  }
+}

--- a/modules/mock_server/test/snippets/programmatic_mode.gleam
+++ b/modules/mock_server/test/snippets/programmatic_mode.gleam
@@ -1,0 +1,24 @@
+//// Programmatic mode snippet from README.
+
+import dream_mock_server/server
+import gleam/erlang/process
+import gleam/int
+import snippets/http_helper
+
+pub fn run() -> Result(Bool, String) {
+  let port = 19_920
+  let assert Ok(handle) = server.start(port)
+  process.sleep(200)
+
+  let url = "http://localhost:" <> int.to_string(port) <> "/text"
+  let result = http_helper.get(url)
+
+  server.stop(handle)
+  process.sleep(200)
+
+  case result {
+    Ok(#(200, body)) -> Ok(body != "")
+    Ok(_) -> Error("Unexpected status")
+    Error(e) -> Error(e)
+  }
+}

--- a/modules/mock_server/test/snippets_test.gleam
+++ b/modules/mock_server/test/snippets_test.gleam
@@ -1,0 +1,33 @@
+//// Test all README snippets by actually running them.
+////
+//// This ensures documentation examples remain valid and executable.
+
+import gleeunit/should
+import snippets/config_mode_method_specific
+import snippets/config_mode_ordering
+import snippets/config_mode_prefix
+import snippets/programmatic_mode
+
+pub fn programmatic_mode_test() {
+  programmatic_mode.run()
+  |> should.be_ok()
+  |> should.equal(True)
+}
+
+pub fn config_mode_prefix_test() {
+  config_mode_prefix.run()
+  |> should.be_ok()
+  |> should.equal(True)
+}
+
+pub fn config_mode_method_specific_test() {
+  config_mode_method_specific.run()
+  |> should.be_ok()
+  |> should.equal(True)
+}
+
+pub fn config_mode_ordering_test() {
+  config_mode_ordering.run()
+  |> should.be_ok()
+  |> should.equal(True)
+}


### PR DESCRIPTION
Release from develop to main.

**Included changes:**
- feat(mock_server): add startup route config and bump to 1.1.0
- Merge of feature/mock-server-config-at-startup