### PR TITLE
HTTP Client Release 5.0.0: Structured Responses, Typed Errors, and Full Streaming Playback

### DIFF
--- a/examples/custom_context/src/controllers/posts_controller.gleam
+++ b/examples/custom_context/src/controllers/posts_controller.gleam
@@ -52,9 +52,11 @@ fn make_request_and_respond(user_id: String, post_id: String) -> Response {
     |> client.add_header("User-Agent", "Dream-Custom-Context-Example")
 
   case client.send(req) {
-    Ok(body) ->
+    Ok(client.HttpResponse(body: body, ..)) ->
       text_response(status.ok, post_view.format_show(user_id, post_id, body))
-    Error(error) ->
+    Error(client.ResponseError(response: client.HttpResponse(body: body, ..))) ->
+      text_response(status.internal_server_error, post_view.format_error(body))
+    Error(client.RequestError(message: error)) ->
       text_response(status.internal_server_error, post_view.format_error(error))
   }
 }

--- a/examples/simple/src/controllers/posts_controller.gleam
+++ b/examples/simple/src/controllers/posts_controller.gleam
@@ -51,9 +51,11 @@ fn make_request_and_respond(user_id: String, post_id: String) -> Response {
     |> client.add_header("User-Agent", "Dream-Simple-Example")
 
   case client.send(req) {
-    Ok(body) ->
+    Ok(client.HttpResponse(body: body, ..)) ->
       text_response(status.ok, post_view.format_show(user_id, post_id, body))
-    Error(error) ->
+    Error(client.ResponseError(response: client.HttpResponse(body: body, ..))) ->
+      text_response(status.internal_server_error, post_view.format_error(body))
+    Error(client.RequestError(message: error)) ->
       text_response(status.internal_server_error, post_view.format_error(error))
   }
 }

--- a/examples/streaming/src/controllers/stream_controller.gleam
+++ b/examples/streaming/src/controllers/stream_controller.gleam
@@ -81,8 +81,14 @@ pub fn new(
     |> client.timeout(5000)
 
   case client.send(req) {
-    Ok(body) -> text_response(status.ok, stream_view.format_fetch(body))
-    Error(error) ->
+    Ok(client.HttpResponse(body: body, ..)) ->
+      text_response(status.ok, stream_view.format_fetch(body))
+    Error(client.ResponseError(response: client.HttpResponse(body: body, ..))) ->
+      text_response(
+        status.internal_server_error,
+        stream_view.format_error(body),
+      )
+    Error(client.RequestError(message: error)) ->
       text_response(
         status.internal_server_error,
         stream_view.format_error(error),

--- a/modules/http_client/CHANGELOG.md
+++ b/modules/http_client/CHANGELOG.md
@@ -5,6 +5,74 @@ All notable changes to `dream_http_client` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.0.0 - 2026-02-16
+
+### Breaking Changes
+
+- **`send()` now returns `Result(HttpResponse, SendError)`** instead of `Result(String, String)`.
+  - `HttpResponse` carries `status: Int`, `headers: List(Header)`, and `body: String`.
+  - `SendError` has two variants:
+    - `ResponseError(response: HttpResponse)` — server returned 4xx/5xx (full response available)
+    - `RequestError(message: String)` — connection failure, timeout, DNS error, or recorder error
+  - HTTP error responses (status >= 400) are now routed to `Error(ResponseError(...))` instead of `Ok(body)`.
+  - Successful responses (status < 400) are `Ok(HttpResponse(...))`.
+
+### Fixed
+
+- **HTTP 4xx/5xx responses no longer silently succeed.** In 4.x, a 404 or 500 response
+  came back as `Ok(body)`, identical to a 200. Callers had no way to detect failure without
+  parsing the body. Now 4xx/5xx responses are routed to `Error(ResponseError(response))`
+  with the full `HttpResponse` available for inspection — status code, headers, and body.
+- **`start_stream()` playback no longer errors.** In 4.x, `start_stream()` with a recorder
+  in playback mode returned `Error("Message-based streaming does not support playback mode")`.
+  Callback-based streaming could record but never play back, forcing tests to hit real endpoints
+  every run. Now `start_stream()` replays recorded chunks directly via your callbacks.
+- **`dream_opensearch` adapted to `client.new()`.** The opensearch client was still using the
+  pre-4.0 `client.new` (without parentheses), which worked by accident in 4.x but was
+  technically incorrect per the 4.0 migration guide.
+
+### Added
+
+- **`HttpResponse` type** — carries `status: Int`, `headers: List(Header)`, and `body: String`
+  for complete HTTP response inspection.
+- **`SendError` type** — typed error variants distinguishing HTTP errors (`ResponseError`) from
+  transport failures (`RequestError`), replacing opaque `Error(String)`.
+- **`start_stream()` playback support.** When a recorder is attached and a matching recording
+  exists, `start_stream()` replays recorded chunks directly via your `on_stream_start`,
+  `on_stream_chunk`, and `on_stream_end` callbacks — no network calls required. All three
+  execution modes (`send()`, `stream_yielder()`, `start_stream()`) now fully support both
+  recording and playback.
+
+### Migration Guide
+
+**Before (4.x):**
+
+```gleam
+case client.send(request) {
+  Ok(body) -> use_body(body)
+  Error(message) -> handle_error(message)
+}
+```
+
+**After (5.0):**
+
+```gleam
+case client.send(request) {
+  Ok(client.HttpResponse(status: status, headers: headers, body: body)) ->
+    use_response(status, headers, body)
+  Error(client.ResponseError(response: client.HttpResponse(body: body, ..))) ->
+    handle_http_error(body)
+  Error(client.RequestError(message: message)) ->
+    handle_connection_error(message)
+}
+```
+
+**Quick migration** — if you only need the body:
+
+```gleam
+let assert Ok(client.HttpResponse(body: body, ..)) = client.send(request)
+```
+
 ## 4.1.0 - 2026-01-28
 
 ### Changed

--- a/modules/http_client/README.md
+++ b/modules/http_client/README.md
@@ -70,10 +70,12 @@ gleam add dream_http_client
 Make a simple HTTP request:
 
 ```gleam
-import dream_http_client/client.{host, method, path, port, scheme, send}
+import dream_http_client/client.{
+  type HttpResponse, type SendError, host, method, path, port, scheme, send,
+}
 import gleam/http
 
-pub fn simple_get() -> Result(String, String) {
+pub fn simple_get() -> Result(HttpResponse, SendError) {
   client.new()
   |> method(http.Get)
   |> scheme(http.Http)
@@ -97,7 +99,10 @@ dream_http_client provides three execution modes. Choose based on your use case:
 **Best for:** JSON APIs, small responses
 
 ```gleam
-import dream_http_client/client.{host, path, port, scheme, send}
+import dream_http_client/client.{
+  HttpResponse, RequestError, ResponseError,
+  host, path, port, scheme, send,
+}
 import gleam/http
 
 let result =
@@ -109,8 +114,9 @@ let result =
   |> send()
 
 case result {
-  Ok(body) -> Ok(body)
-  Error(msg) -> Error(msg)
+  Ok(HttpResponse(body: body, ..)) -> Ok(body)
+  Error(ResponseError(response: response)) -> Error(response.body)
+  Error(RequestError(message: msg)) -> Error(msg)
 }
 ```
 
@@ -207,6 +213,17 @@ pub fn stream_and_print() -> Result(Nil, String) {
 ## Recording & Playback
 
 Record HTTP requests/responses for testing, debugging, and offline development.
+All three execution modes fully support both recording and playback:
+
+| Mode               | Record | Playback |
+|:-------------------|:------:|:--------:|
+| `send()`           | ✓      | ✓        |
+| `stream_yielder()` | ✓      | ✓        |
+| `start_stream()`   | ✓      | ✓        |
+
+Streaming recordings capture each chunk along with timing information.
+The same fixture format is shared between `stream_yielder()` and `start_stream()`,
+so recordings made with one can be played back by either.
 
 ### Quick Example
 
@@ -470,7 +487,7 @@ client.new()
 
 **Blocking:**
 
-- `send(req) -> Result(String, String)` - Returns complete response body
+- `send(req) -> Result(HttpResponse, SendError)` - Returns complete response (status, headers, body)
 
 **Yielder Streaming:**
 
@@ -484,6 +501,14 @@ client.new()
 
 ### Types
 
+**`Header`** - HTTP header with `name: String` and `value: String`
+
+**`HttpResponse`** - Complete HTTP response with `status: Int`, `headers: List(Header)`, and `body: String`
+
+**`SendError`** - Error from `send()`:
+- `ResponseError(response: HttpResponse)` — HTTP error (4xx/5xx) with full response
+- `RequestError(message: String)` — Transport failure (connection, timeout, DNS)
+
 **`StreamHandle`** - Opaque identifier for process-based streams
 
 ### Error Handling
@@ -491,7 +516,10 @@ client.new()
 All modes use `Result` types for explicit error handling:
 
 ```gleam
-import dream_http_client/client.{host, path, port, scheme, send, timeout}
+import dream_http_client/client.{
+  HttpResponse, RequestError, ResponseError,
+  host, path, port, scheme, send, timeout,
+}
 import gleam/http
 import gleam/io
 
@@ -504,11 +532,15 @@ let request =
   |> timeout(5000)
 
 case send(request) {
-  Ok(body) -> {
+  Ok(HttpResponse(body: body, ..)) -> {
     io.println(body)
     Ok(body)
   }
-  Error(msg) -> {
+  Error(ResponseError(response: response)) -> {
+    io.println_error("HTTP error " <> int.to_string(response.status))
+    Error(response.body)
+  }
+  Error(RequestError(message: msg)) -> {
     io.println_error("Request failed: " <> msg)
     Error(msg)
   }
@@ -540,6 +572,8 @@ All examples are tested and verified. See [test/snippets/](test/snippets/) for c
 
 - [Record and playback](test/snippets/recording_basic.gleam) - Testing without network
 - [Playback-only testing](test/snippets/recording_playback.gleam) - Test fixtures without network
+- [Recording with stream_yielder()](test/snippets/recording_stream_yielder.gleam) - Record and playback yielder streams
+- [Recording with start_stream()](test/snippets/recording_start_stream.gleam) - Record and playback callback streams
 - [Custom request keys](test/snippets/matching_config.gleam) - Configure request matching
 - [Request transformers](test/snippets/recording_transformer.gleam) - Scrub secrets before keying/persistence
 - [Response transformers](test/snippets/recording_response_transformer.gleam) - Scrub secrets from recorded responses

--- a/modules/http_client/gleam.toml
+++ b/modules/http_client/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream_http_client"
-version = "4.1.0"
+version = "5.0.0"
 description = "Type-safe HTTP client for Gleam with streaming support"
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }

--- a/modules/http_client/releases/release-5.0.0.md
+++ b/modules/http_client/releases/release-5.0.0.md
@@ -1,0 +1,389 @@
+# dream_http_client 5.0.0 Release Notes
+
+**Release Date:** February 16, 2026
+
+dream_http_client 5.0.0 makes `send()` return the full HTTP response — status
+code, headers, and body — and introduces typed errors that distinguish HTTP
+failures from transport failures at the type level.
+
+## Why this release exists
+
+In 4.x, `send()` returned `Result(String, String)` — just the response body on
+success, and a message string on failure. This had three problems:
+
+1. **4xx/5xx responses were invisible.** A 404 came back as `Ok(body)`, identical
+   to a 200. Callers had no way to distinguish success from HTTP errors without
+   parsing the body or making a second request.
+
+2. **Response metadata was discarded.** Status codes and headers were consumed
+   internally but never surfaced. If you needed a status code, Content-Type, or
+   Set-Cookie header, you were out of luck.
+
+3. **All errors were opaque strings.** Connection refused and 500 Internal Server
+   Error both arrived as `Error("some message")`. Callers couldn't branch on the
+   type of failure without string parsing.
+
+5.0.0 fixes all three. `send()` now returns a structured `HttpResponse` on
+success, routes HTTP errors to a typed `ResponseError` variant (with the full
+response available for inspection), and wraps transport failures in a
+`RequestError` variant. No new functions were added — `send()` just returns
+what an HTTP client should have always returned.
+
+## Key Highlights
+
+- **`send()` returns `HttpResponse`** — status, headers (as `List(Header)`), and body
+- **HTTP errors carry the full response** — inspect status codes, parse error bodies, read headers
+- **Typed error variants** — `ResponseError` for 4xx/5xx, `RequestError` for transport failures
+- **`Ok` always means success** — status < 400 guaranteed, no more silent error responses
+- **Full recording/playback for all execution modes** — `send()`, `stream_yielder()`, and `start_stream()` all support recording and playback
+
+## New Types
+
+### `HttpResponse`
+
+Complete HTTP response returned by `send()`:
+
+```gleam
+pub type HttpResponse {
+  HttpResponse(status: Int, headers: List(Header), body: String)
+}
+```
+
+- `status` — HTTP status code (200, 301, 404, 500, etc.)
+- `headers` — response headers as `List(Header)`, the same type used throughout the module
+- `body` — complete response body as a UTF-8 string
+
+### `SendError`
+
+Typed error variants returned by `send()`:
+
+```gleam
+pub type SendError {
+  ResponseError(response: HttpResponse)
+  RequestError(message: String)
+}
+```
+
+- `ResponseError` — the server responded with status >= 400. The full `HttpResponse`
+  is available with status, headers, and body (typically containing error details
+  from the API).
+- `RequestError` — the request never completed. Common causes: connection refused,
+  DNS resolution failure, timeout, recorder errors.
+
+## Streaming Playback for `start_stream()`
+
+In 4.x, `start_stream()` could **record** streaming responses but could not **play
+them back** from fixtures. Playback attempted to inject messages into the caller's
+mailbox, which isn't possible from a recording. In practice this meant callback-based
+streaming tests required real network calls every run.
+
+5.0.0 fixes this. When a recorder is attached and a matching recording exists,
+`start_stream()` replays the recorded chunks directly via your callbacks —
+`on_stream_start`, `on_stream_chunk`, and `on_stream_end` are called in sequence
+with the recorded data. No network calls, no delays. The same `StreamingResponse`
+format used by `stream_yielder()` playback is reused, so existing recordings work
+with both execution modes.
+
+All three execution modes now fully support recording and playback:
+
+| Mode               | Record | Playback |
+|:-------------------|:------:|:--------:|
+| `send()`           | ✓      | ✓        |
+| `stream_yielder()` | ✓      | ✓        |
+| `start_stream()`   | ✓      | ✓ (new)  |
+
+## Bug Fixes
+
+### 1) HTTP 4xx/5xx responses no longer silently succeed
+
+In 4.x, a 404 or 500 response came back as `Ok(body)`, identical to a 200. This
+was the root cause of several downstream bugs: callers had no way to detect
+failure without parsing the body, and error-handling code paths were never
+triggered for server errors.
+
+**Before (4.x) — silent failure:**
+
+```gleam
+let assert Ok(body) = client.send(request)
+// body could be "Hello, World!" OR '{"error":"not found"}' — no way to tell
+```
+
+**After (5.0.0) — failure is explicit:**
+
+```gleam
+case client.send(request) {
+  Ok(HttpResponse(body: body, ..)) ->
+    // Guaranteed status < 400
+    Ok(body)
+  Error(ResponseError(response: response)) ->
+    // HTTP 4xx/5xx — status, headers, and error body available
+    Error(response.body)
+  Error(RequestError(message: msg)) ->
+    // Transport failure
+    Error(msg)
+}
+```
+
+### 2) `start_stream()` playback no longer errors
+
+In 4.x, calling `start_stream()` with a recorder in playback mode returned:
+
+```
+Error("Message-based streaming does not support playback mode. Use stream_yielder() instead.")
+```
+
+This meant callback-based streaming could **record** responses but could never
+**play them back**. Tests using `start_stream()` had to hit real endpoints on
+every run, making CI unreliable and slow.
+
+5.0.0 replays recorded chunks directly via your callbacks — `on_stream_start`,
+`on_stream_chunk`, and `on_stream_end` are called in sequence with the recorded
+data. No network calls, no workarounds needed.
+
+### 3) `dream_opensearch` used pre-4.0 `client.new` syntax
+
+The opensearch client was using `client.new` (without parentheses), which was the
+pre-4.0 syntax. This worked by accident in 4.x because Gleam treats a zero-arg
+function reference as callable, but it was technically incorrect per the 4.0
+migration guide. Updated to `client.new()`.
+
+## Breaking Changes
+
+### 1) `send()` return type changed
+
+**Before (4.x):**
+
+```gleam
+pub fn send(request) -> Result(String, String)
+```
+
+**After (5.0.0):**
+
+```gleam
+pub fn send(request) -> Result(HttpResponse, SendError)
+```
+
+### 2) HTTP error responses moved from `Ok` to `Error`
+
+4xx and 5xx responses previously came back as `Ok(body)`. Now they are
+`Error(ResponseError(response))` with the full `HttpResponse` available:
+
+| Condition            | 4.x                    | 5.0.0                                      |
+|:---------------------|:----------------------|:--------------------------------------------|
+| Status 200           | `Ok("body")`          | `Ok(HttpResponse(status: 200, ..))`        |
+| Status 404           | `Ok("not found")`     | `Error(ResponseError(response: HttpResponse(status: 404, ..)))` |
+| Connection refused   | `Error("message")`    | `Error(RequestError(message: "message"))`  |
+
+This means:
+
+- `Ok(HttpResponse(..))` — **guaranteed** successful response (status < 400)
+- `Error(ResponseError(response))` — HTTP error with the full response
+- `Error(RequestError(message))` — transport/connection failure
+
+### 3) Error strings are now typed
+
+All `Error("some message")` values are now wrapped in `RequestError`:
+
+```gleam
+// Before:
+Error("Connection refused")
+
+// After:
+Error(RequestError(message: "Connection refused"))
+```
+
+## Migration Guide
+
+### Quick migration — just extract the body
+
+If you only need the body and want the smallest possible diff:
+
+**Before:**
+
+```gleam
+let assert Ok(body) = client.send(request)
+```
+
+**After:**
+
+```gleam
+let assert Ok(client.HttpResponse(body: body, ..)) = client.send(request)
+```
+
+### Recommended — full pattern match
+
+Handle all three result cases explicitly:
+
+```gleam
+case client.send(request) {
+  Ok(HttpResponse(status: status, headers: headers, body: body)) -> {
+    // Guaranteed status < 400
+    use_response(status, headers, body)
+  }
+
+  Error(ResponseError(response: response)) -> {
+    // HTTP error (4xx/5xx) — response.body often contains error details
+    handle_http_error(response.status, response.body)
+  }
+
+  Error(RequestError(message: message)) -> {
+    // Connection failure, timeout, DNS error, etc.
+    handle_transport_error(message)
+  }
+}
+```
+
+### Real-world improvement
+
+This is why the major version bump is worth it:
+
+**Before (4.x) — HTTP errors were invisible:**
+
+```gleam
+case client.send(request) {
+  Ok(body) -> {
+    // Could be 200 or 404 — no way to tell!
+    // Have to parse the body to detect errors
+    case json.decode(body, error_decoder) {
+      Ok(api_error) -> Error(api_error.message)
+      Error(_) -> Ok(body)
+    }
+  }
+  Error(msg) -> Error(msg)
+}
+```
+
+**After (5.0.0) — `Ok` always means success:**
+
+```gleam
+case client.send(request) {
+  Ok(response) -> {
+    // Guaranteed success — just use the body
+    Ok(response.body)
+  }
+  Error(ResponseError(response: response)) -> {
+    // HTTP error — status, headers, and body are all available
+    Error("HTTP " <> int.to_string(response.status) <> ": " <> response.body)
+  }
+  Error(RequestError(message: msg)) -> {
+    // Transport failure — no HTTP response at all
+    Error("Connection failed: " <> msg)
+  }
+}
+```
+
+### Migrating error handling
+
+If you were pattern matching on `Error(String)`:
+
+**Before:**
+
+```gleam
+case client.send(request) {
+  Ok(body) -> process(body)
+  Error(msg) -> log_error(msg)
+}
+```
+
+**After:**
+
+```gleam
+case client.send(request) {
+  Ok(response) -> process(response.body)
+  Error(ResponseError(response: response)) -> log_error(response.body)
+  Error(RequestError(message: msg)) -> log_error(msg)
+}
+```
+
+## Backward Compatibility
+
+### What didn't change
+
+- **Builder API** — `client.new()`, `host()`, `path()`, `method()`, `headers()`,
+  `body()`, `timeout()`, etc. are all unchanged
+- **Recorder API** — `recorder.new()`, `directory()`, `mode()`, `start()`, `stop()`,
+  `key()`, `request_transformer()`, `response_transformer()` are all unchanged
+- **Streaming APIs** — `stream_yielder()`, `start_stream()`, `await_stream()`,
+  `cancel_stream_handle()`, `is_stream_active()` are all unchanged
+- **Recording format** — existing fixture files on disk are fully compatible;
+  `StreamingResponse` recordings created by `stream_yielder()` or `start_stream()`
+  in record mode are playable by both streaming APIs
+
+### What changed
+
+- `send()` return type: `Result(String, String)` → `Result(HttpResponse, SendError)`
+- HTTP 4xx/5xx responses: `Ok(body)` → `Error(ResponseError(response))`
+- Transport errors: `Error(message)` → `Error(RequestError(message: message))`
+
+## Test Coverage
+
+All 134 tests pass:
+
+```
+134 passed, no failures
+```
+
+New tests added for this release:
+
+- **Status code boundary tests** — verifies the 399/400 boundary is correct for
+  200, 201, 204, 399 (all `Ok`), and 400, 401, 503 (all `Error(ResponseError)`)
+- **HttpResponse field verification** — confirms status, headers, and body are
+  populated correctly for both success and error responses
+- **Header type verification** — confirms headers arrive as `List(Header)`, not
+  raw tuples
+- **Typed error verification** — confirms `ResponseError` and `RequestError`
+  variants are used correctly across all error paths
+- **Recording playback preservation** — verifies recorded responses preserve
+  status, headers, and body through the record/playback cycle
+- **Streaming recording with `stream_yielder()`** — records and plays back a
+  yielder stream, verifying byte counts match
+- **Streaming recording with `start_stream()`** — records and plays back a
+  callback-based stream, verifying byte counts match
+- **`start_stream()` playback with `StreamingResponse`** — manually creates a
+  streaming recording and verifies all callbacks fire with correct data
+- **`start_stream()` playback with `BlockingResponse`** — verifies the body is
+  delivered as a single chunk when a blocking recording is replayed via callbacks
+- **`start_stream()` playback miss** — verifies fall-through to live HTTP when
+  no matching recording exists
+- **`transform_response()` with transformer** — directly calls the public
+  function and verifies the transformer is applied
+- **`transform_response()` without transformer** — verifies the original
+  response is returned unchanged when no transformer is configured
+
+## Upgrading
+
+Update your dependency:
+
+```toml
+[dependencies]
+dream_http_client = ">= 5.0.0 and < 6.0.0"
+```
+
+Then run:
+
+```bash
+gleam deps download
+```
+
+### Downstream consumers
+
+If you use `dream_opensearch`, update to `>= 2.1.0` which adapts to the new
+`send()` return type. The `dream_opensearch` API itself is unchanged — it
+continues to return `Result(String, String)` by extracting the body internally.
+
+## Documentation
+
+- [dream_http_client hexdocs](https://hexdocs.pm/dream_http_client) — v5.0.0
+- [README](https://github.com/TrustBound/dream/tree/main/modules/http_client)
+- [Tested snippets](https://github.com/TrustBound/dream/tree/main/modules/http_client/test/snippets)
+
+## Community
+
+- [Full Documentation](https://github.com/TrustBound/dream/tree/main/modules/http_client)
+- [Discussions](https://github.com/TrustBound/dream/discussions)
+- [Report Issues](https://github.com/TrustBound/dream/issues)
+- [Contributing Guide](https://github.com/TrustBound/dream/blob/main/CONTRIBUTING.md)
+
+---
+
+**Full Changelog:** [CHANGELOG.md](https://github.com/TrustBound/dream/blob/main/modules/http_client/CHANGELOG.md)

--- a/modules/http_client/src/dream_http_client/client.gleam
+++ b/modules/http_client/src/dream_http_client/client.gleam
@@ -36,7 +36,9 @@
 //// ## Recording and playback
 ////
 //// Attach a recorder with `recorder()` to record real HTTP traffic to disk, or
-//// to play back recordings without network calls.
+//// to play back recordings without network calls. All three execution modes
+//// (`send()`, `stream_yielder()`, `start_stream()`) fully support both
+//// recording and playback.
 ////
 //// ```gleam
 //// import dream_http_client/client.{host, path, recorder, send}
@@ -119,6 +121,70 @@ import gleam/yielder
 /// - Headers are stored in the order they were added
 pub type Header {
   Header(name: String, value: String)
+}
+
+/// Complete HTTP response with status code, headers, and body.
+///
+/// Returned by `send()` for successful HTTP responses (status < 400).
+/// Also available inside `ResponseError` for HTTP error responses (status >= 400).
+///
+/// ## Fields
+///
+/// - `status`: HTTP status code (e.g. 200, 301, 404, 500)
+/// - `headers`: Response headers as `List(Header)` — includes Content-Type,
+///   Content-Length, Set-Cookie, and any other headers the server sent
+/// - `body`: Complete response body as a UTF-8 string
+///
+/// ## Example
+///
+/// ```gleam
+/// case client.send(request) {
+///   Ok(HttpResponse(status: 200, headers: headers, body: body)) ->
+///     process_success(headers, body)
+///   Ok(HttpResponse(status: status, body: body, ..)) ->
+///     handle_redirect(status, body)
+///   Error(_) -> handle_error()
+/// }
+/// ```
+pub type HttpResponse {
+  HttpResponse(status: Int, headers: List(Header), body: String)
+}
+
+/// Error types returned by `send()`.
+///
+/// ## Variants
+///
+/// - `ResponseError(response: HttpResponse)` — the server responded with a
+///   4xx or 5xx status code. The full `HttpResponse` is available with status,
+///   headers, and body. The body typically contains error details (e.g. JSON
+///   error messages from an API, or HTML error pages).
+///
+/// - `RequestError(message: String)` — the request could not be completed.
+///   The `message` describes what went wrong. Common causes:
+///   - Connection refused (server not running)
+///   - DNS resolution failure (hostname not found)
+///   - Timeout (server did not respond in time)
+///   - Recorder errors (ambiguous recording match, missing fixture)
+///   - Streaming response found when blocking response expected
+///
+/// ## Example
+///
+/// ```gleam
+/// case client.send(request) {
+///   Ok(response) ->
+///     // Guaranteed status < 400
+///     io.println("Got " <> int.to_string(response.status))
+///   Error(ResponseError(response: response)) ->
+///     // HTTP error — inspect response.status, response.body
+///     io.println("HTTP " <> int.to_string(response.status))
+///   Error(RequestError(message: message)) ->
+///     // Transport failure — no HTTP response at all
+///     io.println("Failed: " <> message)
+/// }
+/// ```
+pub type SendError {
+  ResponseError(response: HttpResponse)
+  RequestError(message: String)
 }
 
 /// HTTP client request configuration
@@ -946,7 +1012,7 @@ pub opaque type StreamHandle {
 /// Make a blocking HTTP request and get the complete response
 ///
 /// Sends an HTTP request and collects all response chunks, returning the
-/// complete response body as a string. This is ideal for:
+/// complete response with status code, headers, and body. This is ideal for:
 ///
 /// - JSON API responses
 /// - Small files or documents
@@ -955,20 +1021,30 @@ pub opaque type StreamHandle {
 /// For large responses or when you need non-blocking streaming, use
 /// `stream_yielder()` or `start_stream()` instead.
 ///
+/// ## Recording and Playback
+///
+/// When a recorder is attached (via `recorder()`), this function fully supports
+/// both recording and playback. In record mode, the real response is persisted
+/// to disk. In playback mode, the recorded response is returned without making
+/// a network call.
+///
 /// ## Parameters
 ///
 /// - `client_request`: The configured HTTP request
 ///
 /// ## Returns
 ///
-/// - `Ok(String)`: The complete response body as a string
-/// - `Error(String)`: An error message if the request failed
+/// - `Ok(HttpResponse)`: Successful response (status < 400) with status, headers, and body
+/// - `Error(ResponseError(response))`: HTTP error response (status >= 400) with full response
+/// - `Error(RequestError(message))`: Connection failure, timeout, or other transport error
 ///
 /// ## Example
 ///
 /// ```gleam
-/// import dream_http_client/client.{host, path, add_header, send}
-/// import gleam/json.{decode}
+/// import dream_http_client/client.{
+///   HttpResponse, RequestError, ResponseError,
+///   host, path, add_header, send,
+/// }
 ///
 /// let result = client.new()
 ///   |> host("api.example.com")
@@ -977,17 +1053,20 @@ pub opaque type StreamHandle {
 ///   |> send()
 ///
 /// case result {
-///   Ok(body) -> {
-///     case decode(body, user_decoder) {
+///   Ok(HttpResponse(body: body, ..)) -> {
+///     case json.decode(body, user_decoder) {
 ///       Ok(user) -> Ok(user)
 ///       Error(json_error) ->
-///         Error("Invalid JSON response: " <> string.inspect(json_error))
+///         Error("Invalid JSON: " <> string.inspect(json_error))
 ///     }
 ///   }
-///   Error(error_message) -> Error("Request failed: " <> error_message)
+///   Error(ResponseError(response)) ->
+///     Error("HTTP " <> int.to_string(response.status) <> ": " <> response.body)
+///   Error(RequestError(message)) ->
+///     Error("Request failed: " <> message)
 /// }
 /// ```
-pub fn send(client_request: ClientRequest) -> Result(String, String) {
+pub fn send(client_request: ClientRequest) -> Result(HttpResponse, SendError) {
   case client_request.recorder {
     option.Some(recorder_instance) ->
       send_with_recorder(client_request, recorder_instance)
@@ -997,14 +1076,14 @@ pub fn send(client_request: ClientRequest) -> Result(String, String) {
 
 fn send_without_recorder(
   client_request: ClientRequest,
-) -> Result(String, String) {
+) -> Result(HttpResponse, SendError) {
   send_client_request_to_httpc(client_request)
 }
 
 fn send_with_recorder(
   client_request: ClientRequest,
   recorder_instance: recorder.Recorder,
-) -> Result(String, String) {
+) -> Result(HttpResponse, SendError) {
   let recorded_request = client_request_to_recorded_request(client_request)
 
   case recorder.find_recording(recorder_instance, recorded_request) {
@@ -1012,19 +1091,20 @@ fn send_with_recorder(
       handle_recorded_blocking_response(response)
     Ok(option.None) ->
       send_and_maybe_record(client_request, recorder_instance, recorded_request)
-    Error(reason) -> Error(reason)
+    Error(reason) -> Error(RequestError(message: reason))
   }
 }
 
 fn handle_recorded_blocking_response(
   response: recording.RecordedResponse,
-) -> Result(String, String) {
+) -> Result(HttpResponse, SendError) {
   case response {
-    recording.BlockingResponse(_, _, body) -> Ok(body)
+    recording.BlockingResponse(status, headers, body) ->
+      response_result(status, headers, body)
     recording.StreamingResponse(_, _, _) ->
-      Error(
-        "Recording contains streaming response, use stream_yielder() instead",
-      )
+      Error(RequestError(
+        message: "Recording contains streaming response, use stream_yielder() instead",
+      ))
   }
 }
 
@@ -1032,7 +1112,7 @@ fn send_and_maybe_record(
   client_request: ClientRequest,
   recorder_instance: recorder.Recorder,
   recorded_request: recording.RecordedRequest,
-) -> Result(String, String) {
+) -> Result(HttpResponse, SendError) {
   case send_client_request_to_httpc_with_meta(client_request) {
     Ok(#(status, headers, body)) -> {
       let recorded_response =
@@ -1055,9 +1135,9 @@ fn send_and_maybe_record(
         response_for_recording,
       )
 
-      Ok(body)
+      response_result(status, headers, body)
     }
-    Error(error_message) -> Error(error_message)
+    Error(error_message) -> Error(RequestError(message: error_message))
   }
 }
 
@@ -1078,9 +1158,11 @@ fn record_response_if_needed(
 
 fn send_client_request_to_httpc(
   client_request: ClientRequest,
-) -> Result(String, String) {
-  send_client_request_to_httpc_with_meta(client_request)
-  |> result.map(fn(meta) { meta.2 })
+) -> Result(HttpResponse, SendError) {
+  case send_client_request_to_httpc_with_meta(client_request) {
+    Ok(#(status, headers, body)) -> response_result(status, headers, body)
+    Error(error_message) -> Error(RequestError(message: error_message))
+  }
 }
 
 fn send_client_request_to_httpc_with_meta(
@@ -1155,6 +1237,19 @@ fn send_sync(
 /// - Scripts or one-off operations
 ///
 /// **For OTP actors with concurrency, use `start_stream()` instead.**
+///
+/// ## Recording and Playback
+///
+/// When a recorder is attached (via `recorder()`), this function fully supports
+/// both recording and playback:
+///
+/// - **Record mode**: Streams from the real server and records chunks to disk,
+///   capturing timing information between chunks for realistic replay.
+/// - **Playback mode**: Yields recorded chunks from the fixture file. No network
+///   calls are made.
+///
+/// The same `StreamingResponse` fixture format is shared with `start_stream()`,
+/// so recordings made with either function can be played back by both.
 ///
 /// ## Error Semantics
 ///
@@ -1399,6 +1494,23 @@ fn tuples_to_headers(tuples: List(#(String, String))) -> List(Header) {
   list.map(tuples, fn(t) { Header(name: t.0, value: t.1) })
 }
 
+fn response_result(
+  status: Int,
+  headers: List(#(String, String)),
+  body: String,
+) -> Result(HttpResponse, SendError) {
+  let response =
+    HttpResponse(
+      status: status,
+      headers: tuples_to_headers(headers),
+      body: body,
+    )
+  case status >= 400 {
+    True -> Error(ResponseError(response: response))
+    False -> Ok(response)
+  }
+}
+
 fn handle_yielder_start_with_state(
   state: YielderState,
 ) -> yielder.Step(Result(bytes_tree.BytesTree, String), YielderState) {
@@ -1568,9 +1680,10 @@ fn save_streaming_recording(
 }
 
 // Internal: Start a message-based streaming HTTP request
-// Used by start_stream() to initiate the HTTP stream
+// Used by start_stream() to initiate the low-level HTTP stream via httpc.
+// Note: start_stream() already handles playback via maybe_replay_from_recording()
+// before reaching this function. This path is for live HTTP requests only.
 fn stream_messages(client_request: ClientRequest) -> Result(RequestId, String) {
-  // Check for recorder - if in Record mode, check playback first
   case client_request.recorder {
     option.Some(recorder_instance) ->
       stream_messages_with_recorder(client_request, recorder_instance)
@@ -1586,10 +1699,11 @@ fn stream_messages_with_recorder(
 
   case recorder.find_recording(recorder_instance, recorded_request) {
     Ok(option.Some(_recording)) ->
-      // Found recording - message streaming doesn't support playback
-      // because we can't inject messages into user's mailbox
+      // Safety net: start_stream() replays via maybe_replay_from_recording()
+      // before reaching here. If we land here anyway, it means the low-level
+      // httpc message path cannot replay recordings.
       Error(
-        "Message-based streaming does not support playback mode. Use stream_yielder() instead.",
+        "Unexpected: recording found in stream_messages path. This should have been handled by start_stream() playback.",
       )
     Ok(option.None) ->
       send_stream_messages_to_httpc(
@@ -1974,10 +2088,25 @@ fn pair_with_name(value: String, name: String) -> #(String, String) {
 /// Start an HTTP stream with callback handlers
 ///
 /// Spawns a dedicated process to handle HTTP streaming and calls your callbacks
-/// as messages arrive. This is the recommended API for streaming.
+/// as messages arrive. This is the recommended API for streaming in OTP
+/// applications and concurrent contexts.
 ///
 /// Returns a `StreamHandle` immediately (non-blocking). The stream runs in a
 /// separate process, and your callbacks execute in that process.
+///
+/// ## Recording and Playback
+///
+/// When a recorder is attached (via `recorder()`), this function fully supports
+/// both recording and playback:
+///
+/// - **Record mode**: Streams from the real server and records chunks to disk.
+///   The recorded fixture captures each chunk along with timing information.
+/// - **Playback mode**: Replays recorded chunks directly via your callbacks —
+///   `on_stream_start`, `on_stream_chunk`, and `on_stream_end` are called in
+///   sequence with the recorded data. No network calls are made.
+///
+/// The same `StreamingResponse` fixture format is shared with `stream_yielder()`,
+/// so recordings made with either function can be played back by both.
 ///
 /// ## Parameters
 ///
@@ -2028,25 +2157,91 @@ fn ensure_ets_tables() -> Nil {
 fn ensure_ref_mapping_table_wrapper() -> Nil
 
 fn run_stream_process(request: ClientRequest) -> Nil {
-  // Build selector for HTTP messages
-  let selector =
-    process.new_selector()
-    |> select_stream_messages(fn(msg) { msg })
+  // Try playback from recording first
+  case maybe_replay_from_recording(request) {
+    True -> Nil
+    False -> {
+      // Build selector for HTTP messages
+      let selector =
+        process.new_selector()
+        |> select_stream_messages(fn(msg) { msg })
 
-  let timeout_ms = resolve_timeout(request)
+      let timeout_ms = resolve_timeout(request)
 
-  // Start the stream using internal API
-  case stream_messages(request) {
-    Error(reason) -> {
-      // Call error callback if set
-      case request.on_stream_error {
-        Some(on_error) -> on_error(reason)
+      // Start the stream using internal API
+      case stream_messages(request) {
+        Error(reason) -> {
+          // Call error callback if set
+          case request.on_stream_error {
+            Some(on_error) -> on_error(reason)
+            None -> Nil
+          }
+        }
+        Ok(req_id) -> {
+          // Process messages until stream completes
+          process_stream_loop(selector, req_id, request, timeout_ms)
+        }
+      }
+    }
+  }
+}
+
+/// Check if a matching recording exists and replay it via callbacks.
+/// Returns True if playback was handled, False if the caller should
+/// proceed with a real HTTP stream.
+fn maybe_replay_from_recording(request: ClientRequest) -> Bool {
+  case request.recorder {
+    Some(rec) -> {
+      let recorded_request = client_request_to_recorded_request(request)
+      case recorder.find_recording(rec, recorded_request) {
+        Ok(Some(recording.Recording(_, response))) -> {
+          replay_recorded_stream(request, response)
+          True
+        }
+        _ -> False
+      }
+    }
+    None -> False
+  }
+}
+
+/// Replay a recorded response by directly invoking the stream callbacks.
+/// Handles both StreamingResponse (multiple chunks) and BlockingResponse
+/// (body delivered as a single chunk).
+fn replay_recorded_stream(
+  request: ClientRequest,
+  response: recording.RecordedResponse,
+) -> Nil {
+  case response {
+    recording.StreamingResponse(_, headers, chunks) -> {
+      case request.on_stream_start {
+        Some(cb) -> cb(list.map(headers, fn(h) { Header(h.0, h.1) }))
+        None -> Nil
+      }
+      list.each(chunks, fn(chunk) {
+        case request.on_stream_chunk {
+          Some(cb) -> cb(chunk.data)
+          None -> Nil
+        }
+      })
+      case request.on_stream_end {
+        Some(cb) -> cb([])
         None -> Nil
       }
     }
-    Ok(req_id) -> {
-      // Process messages until stream completes
-      process_stream_loop(selector, req_id, request, timeout_ms)
+    recording.BlockingResponse(_, headers, body) -> {
+      case request.on_stream_start {
+        Some(cb) -> cb(list.map(headers, fn(h) { Header(h.0, h.1) }))
+        None -> Nil
+      }
+      case request.on_stream_chunk {
+        Some(cb) -> cb(<<body:utf8>>)
+        None -> Nil
+      }
+      case request.on_stream_end {
+        Some(cb) -> cb([])
+        None -> Nil
+      }
     }
   }
 }

--- a/modules/http_client/test/dream_http_client_test.gleam
+++ b/modules/http_client/test/dream_http_client_test.gleam
@@ -43,7 +43,7 @@ fn test_server_ready(port: Int) -> Nil {
     |> client.path("/text")
 
   case client.send(test_req) {
-    Ok(body) -> {
+    Ok(client.HttpResponse(body: body, ..)) -> {
       case string.length(body) > 0 {
         True -> Nil
         False -> {
@@ -52,8 +52,8 @@ fn test_server_ready(port: Int) -> Nil {
         }
       }
     }
-    Error(error_msg) -> {
-      io.println("Server not responding: " <> error_msg)
+    Error(error) -> {
+      io.println("Server not responding: " <> string.inspect(error))
       exit_with_error()
     }
   }

--- a/modules/http_client/test/error_handling_test.gleam
+++ b/modules/http_client/test/error_handling_test.gleam
@@ -12,6 +12,7 @@ import dream_http_client/client
 import dream_http_client_test
 import gleam/http
 import gleam/io
+import gleam/list
 import gleam/string
 import gleeunit/should
 
@@ -28,7 +29,7 @@ fn mock_request(path: String) -> client.ClientRequest {
 // send() Error Status Code Tests
 // ============================================================================
 
-/// Test: send() returns body even with 404 status
+/// Test: send() returns ResponseError with 404 status
 pub fn send_404_status_test() {
   // Arrange
   let req = mock_request("/status/404")
@@ -36,23 +37,30 @@ pub fn send_404_status_test() {
   // Act
   let result = client.send(req)
 
-  // Assert - httpc returns body regardless of status code
+  // Assert - 404 comes back as ResponseError with full response
   case result {
-    Ok(body) -> {
+    Error(client.ResponseError(response: client.HttpResponse(
+      status: status,
+      body: body,
+      ..,
+    ))) -> {
+      status |> should.equal(404)
       string.contains(body, "404") |> should.be_true()
     }
-    Error(error_reason) -> {
-      // Connection-level errors are acceptable for status code tests, but log
-      // them so they are visible when debugging.
+    Error(client.RequestError(message: error_reason)) -> {
       io.println(
         "send_404_status_test encountered connection-level error: "
         <> error_reason,
       )
     }
+    Ok(_) -> {
+      io.println("send_404_status_test: expected error, got Ok")
+      should.fail()
+    }
   }
 }
 
-/// Test: send() returns body even with 500 status
+/// Test: send() returns ResponseError with 500 status
 pub fn send_500_status_test() {
   // Arrange
   let req = mock_request("/status/500")
@@ -60,23 +68,30 @@ pub fn send_500_status_test() {
   // Act
   let result = client.send(req)
 
-  // Assert - httpc returns body regardless of status code
+  // Assert - 500 comes back as ResponseError with full response
   case result {
-    Ok(body) -> {
+    Error(client.ResponseError(response: client.HttpResponse(
+      status: status,
+      body: body,
+      ..,
+    ))) -> {
+      status |> should.equal(500)
       string.contains(body, "500") |> should.be_true()
     }
-    Error(error_reason) -> {
-      // Connection-level errors are acceptable for status code tests, but log
-      // them so they are visible when debugging.
+    Error(client.RequestError(message: error_reason)) -> {
       io.println(
         "send_500_status_test encountered connection-level error: "
         <> error_reason,
       )
     }
+    Ok(_) -> {
+      io.println("send_500_status_test: expected error, got Ok")
+      should.fail()
+    }
   }
 }
 
-/// Test: send() returns body with 400 status
+/// Test: send() returns ResponseError with 400 status
 pub fn send_400_status_test() {
   // Arrange
   let req = mock_request("/status/400")
@@ -84,23 +99,30 @@ pub fn send_400_status_test() {
   // Act
   let result = client.send(req)
 
-  // Assert - httpc returns body regardless of status code
+  // Assert - 400 comes back as ResponseError with full response
   case result {
-    Ok(body) -> {
+    Error(client.ResponseError(response: client.HttpResponse(
+      status: status,
+      body: body,
+      ..,
+    ))) -> {
+      status |> should.equal(400)
       string.contains(body, "400") |> should.be_true()
     }
-    Error(error_reason) -> {
-      // Connection-level errors are acceptable for status code tests, but log
-      // them so they are visible when debugging.
+    Error(client.RequestError(message: error_reason)) -> {
       io.println(
         "send_400_status_test encountered connection-level error: "
         <> error_reason,
       )
     }
+    Ok(_) -> {
+      io.println("send_400_status_test: expected error, got Ok")
+      should.fail()
+    }
   }
 }
 
-/// Test: send() returns error on connection failure
+/// Test: send() returns RequestError on connection failure
 pub fn send_connection_failure_test() {
   // Arrange - Use a port that won't have a server listening
   let req =
@@ -114,11 +136,14 @@ pub fn send_connection_failure_test() {
   // Act
   let result = client.send(req)
 
-  // Assert - Should get an error
+  // Assert - Should get a RequestError (transport failure)
   case result {
-    Error(error_msg) -> {
-      // Error message should be informative
+    Error(client.RequestError(message: error_msg)) -> {
       string.length(error_msg) |> should.not_equal(0)
+    }
+    Error(client.ResponseError(_)) -> {
+      io.println("Expected RequestError, got ResponseError")
+      should.fail()
     }
     Ok(_) -> should.fail()
   }
@@ -141,14 +166,20 @@ pub fn send_respects_explicit_request_content_type_test() {
     |> client.body("hello")
 
   case client.send(req) {
-    Ok(body) -> body |> should.equal("text/plain")
-    Error(error_reason) -> {
+    Ok(client.HttpResponse(body: body, ..)) ->
+      body |> should.equal("text/plain")
+    Error(client.ResponseError(response: client.HttpResponse(status: status, ..))) -> {
+      io.println(
+        "send_respects_explicit_request_content_type_test got HTTP error: "
+        <> string.inspect(status),
+      )
+      False |> should.be_true()
+    }
+    Error(client.RequestError(message: error_reason)) -> {
       io.println(
         "send_respects_explicit_request_content_type_test failed: "
         <> error_reason,
       )
-      // This should not be a flaky test: failing here means either the mock server
-      // is down or the request tuple is invalid.
       False |> should.be_true()
     }
   }
@@ -164,14 +195,15 @@ pub fn send_large_response_test() {
 
   // Assert - Should successfully get the large body
   case result {
-    Ok(body) -> {
+    Ok(client.HttpResponse(body: body, ..)) -> {
       // Should be at least 100KB
       string.length(body) |> should.not_equal(0)
       { string.length(body) > 100_000 } |> should.be_true()
     }
-    Error(error_reason) -> {
+    Error(error) -> {
       io.println(
-        "Expected large response to succeed, got error: " <> error_reason,
+        "Expected large response to succeed, got error: "
+        <> string.inspect(error),
       )
       should.fail()
     }
@@ -188,16 +220,138 @@ pub fn send_empty_response_test() {
 
   // Assert - Empty body is not an error
   case result {
-    Ok(body) -> {
+    Ok(client.HttpResponse(body: body, ..)) -> {
       body |> should.equal("")
     }
-    Error(error_reason) -> {
+    Error(error) -> {
       io.println(
-        "Expected empty response to succeed, got error: " <> error_reason,
+        "Expected empty response to succeed, got error: "
+        <> string.inspect(error),
       )
       should.fail()
     }
   }
+}
+
+// ============================================================================
+// Error Message Quality Tests
+// ============================================================================
+
+// ============================================================================
+// HttpResponse Field Verification Tests
+// ============================================================================
+
+/// Test: successful response includes status code 200
+pub fn send_success_includes_status_code_test() {
+  let req = mock_request("/text")
+  let assert Ok(client.HttpResponse(status: status, body: body, ..)) =
+    client.send(req)
+  status |> should.equal(200)
+  body |> should.equal("Hello, World!")
+}
+
+/// Test: successful response includes headers as List(Header)
+pub fn send_success_includes_headers_test() {
+  let req = mock_request("/json")
+  let assert Ok(client.HttpResponse(headers: headers, ..)) = client.send(req)
+
+  // Should have at least one header
+  { headers != [] } |> should.be_true()
+
+  // Headers should be Header type with name/value
+  let has_content_type =
+    list.any(headers, fn(h: client.Header) {
+      string.lowercase(h.name) == "content-type"
+    })
+  has_content_type |> should.be_true()
+}
+
+/// Test: error response includes headers in ResponseError
+pub fn send_error_response_includes_headers_test() {
+  let req = mock_request("/status/404")
+  case client.send(req) {
+    Error(client.ResponseError(response: client.HttpResponse(
+      headers: headers,
+      ..,
+    ))) -> {
+      // Error responses should also carry headers
+      { headers != [] } |> should.be_true()
+      let has_content_type =
+        list.any(headers, fn(h: client.Header) {
+          string.lowercase(h.name) == "content-type"
+        })
+      has_content_type |> should.be_true()
+    }
+    Error(client.RequestError(message: msg)) -> {
+      io.println("Connection error (mock server down?): " <> msg)
+    }
+    Ok(_) -> {
+      io.println("Expected ResponseError for 404, got Ok")
+      should.fail()
+    }
+  }
+}
+
+// ============================================================================
+// Status Code Boundary Tests
+// ============================================================================
+
+/// Test: status 200 returns Ok
+pub fn send_status_200_returns_ok_test() {
+  let req = mock_request("/status/200")
+  let assert Ok(client.HttpResponse(status: status, ..)) = client.send(req)
+  status |> should.equal(200)
+}
+
+/// Test: status 201 returns Ok
+pub fn send_status_201_returns_ok_test() {
+  let req = mock_request("/status/201")
+  let assert Ok(client.HttpResponse(status: status, ..)) = client.send(req)
+  status |> should.equal(201)
+}
+
+/// Test: status 204 returns Ok
+pub fn send_status_204_returns_ok_test() {
+  let req = mock_request("/status/204")
+  let assert Ok(client.HttpResponse(status: status, ..)) = client.send(req)
+  status |> should.equal(204)
+}
+
+/// Test: status 399 returns Ok (just below the error boundary)
+pub fn send_status_399_returns_ok_test() {
+  let req = mock_request("/status/399")
+  let assert Ok(client.HttpResponse(status: status, ..)) = client.send(req)
+  status |> should.equal(399)
+}
+
+/// Test: status 400 returns Error (exactly at the error boundary)
+pub fn send_status_400_returns_error_test() {
+  let req = mock_request("/status/400")
+  let assert Error(client.ResponseError(response: client.HttpResponse(
+    status: status,
+    ..,
+  ))) = client.send(req)
+  status |> should.equal(400)
+}
+
+/// Test: status 401 returns Error
+pub fn send_status_401_returns_error_test() {
+  let req = mock_request("/status/401")
+  let assert Error(client.ResponseError(response: client.HttpResponse(
+    status: status,
+    ..,
+  ))) = client.send(req)
+  status |> should.equal(401)
+}
+
+/// Test: status 503 returns Error
+pub fn send_status_503_returns_error_test() {
+  let req = mock_request("/status/503")
+  let assert Error(client.ResponseError(response: client.HttpResponse(
+    status: status,
+    ..,
+  ))) = client.send(req)
+  status |> should.equal(503)
 }
 
 // ============================================================================
@@ -220,12 +374,16 @@ pub fn error_messages_are_informative_test() {
 
   // Assert - Error message should have substance
   case result {
-    Error(error_msg) -> {
+    Error(client.RequestError(message: error_msg)) -> {
       // Should be more than just "error" or empty
       string.length(error_msg) |> should.not_equal(0)
       // Should not be just "Nil" or similar
       error_msg |> should.not_equal("Nil")
       error_msg |> should.not_equal("nil")
+    }
+    Error(client.ResponseError(_)) -> {
+      io.println("Expected RequestError, got ResponseError")
+      should.fail()
     }
     Ok(_) -> should.fail()
   }

--- a/modules/http_client/test/recorder_client_test.gleam
+++ b/modules/http_client/test/recorder_client_test.gleam
@@ -106,7 +106,7 @@ pub fn send_with_recorder_in_playback_mode_returns_recorded_response_test() {
   let result = client.send(request)
 
   // Assert
-  let assert Ok(body) = result
+  let assert Ok(client.HttpResponse(body: body, ..)) = result
   body |> should.equal("Hello, World!")
 
   // Cleanup
@@ -156,8 +156,11 @@ pub fn send_with_recorder_in_record_mode_records_response_test() {
 
   let request = mock_request("/status/418") |> client.recorder(rec)
 
-  // Act - Record real request
-  let assert Ok(original_body) = client.send(request)
+  // Act - Record real request (418 is a client error, so it comes back as ResponseError)
+  let assert Error(client.ResponseError(response: client.HttpResponse(
+    body: original_body,
+    ..,
+  ))) = client.send(request)
   recorder.stop(rec) |> result.unwrap(Nil)
 
   // Assert - Recording was created
@@ -215,7 +218,10 @@ pub fn send_with_recorder_in_record_mode_records_response_test() {
     |> start()
   let playback_request =
     mock_request("/status/418") |> client.recorder(playback_rec)
-  let assert Ok(playback_body) = client.send(playback_request)
+  let assert Error(client.ResponseError(response: client.HttpResponse(
+    body: playback_body,
+    ..,
+  ))) = client.send(playback_request)
 
   // Assert - Got MODIFIED content, not original (proves we read from file, not real request)
   playback_body |> should.equal("MODIFIED_CONTENT")
@@ -264,8 +270,19 @@ pub fn send_with_recorder_finding_streaming_response_returns_error_test() {
   // Act
   let result = client.send(request)
 
-  // Assert
-  result |> should.be_error()
+  // Assert - should be RequestError, not ResponseError
+  case result {
+    Error(client.RequestError(message: msg)) ->
+      string.contains(msg, "streaming response") |> should.be_true()
+    Error(client.ResponseError(_)) -> {
+      io.println("Expected RequestError, got ResponseError")
+      should.fail()
+    }
+    Ok(_) -> {
+      io.println("Expected error, got Ok")
+      should.fail()
+    }
+  }
 
   // Cleanup
   recorder.stop(playback_rec) |> result.unwrap(Nil)
@@ -367,7 +384,7 @@ pub fn response_transformer_scrubs_persisted_body_but_send_returns_original_test
   let request = mock_request("/text") |> client.recorder(rec)
 
   // Act - send returns the real body
-  let assert Ok(body) = client.send(request)
+  let assert Ok(client.HttpResponse(body: body, ..)) = client.send(request)
   body |> should.equal("Hello, World!")
 
   let assert Ok(_) = recorder.stop(rec)
@@ -416,7 +433,8 @@ pub fn request_transformer_scrubs_persisted_headers_and_still_matches_playback_t
     |> client.recorder(rec)
 
   // Act - record
-  let assert Ok(body) = client.send(request_with_secret)
+  let assert Ok(client.HttpResponse(body: body, ..)) =
+    client.send(request_with_secret)
   body |> should.equal("Hello, World!")
   let assert Ok(_) = recorder.stop(rec)
 
@@ -445,7 +463,8 @@ pub fn request_transformer_scrubs_persisted_headers_and_still_matches_playback_t
     |> client.add_header("Authorization", "Bearer SECRET_2")
     |> client.recorder(playback_rec)
 
-  let assert Ok(playback_body) = client.send(request_with_different_secret)
+  let assert Ok(client.HttpResponse(body: playback_body, ..)) =
+    client.send(request_with_different_secret)
   playback_body |> should.equal("Hello, World!")
 
   // Cleanup
@@ -519,10 +538,153 @@ pub fn send_with_recorder_in_playback_mode_with_ambiguous_key_returns_error_test
   // Assert
   result |> should.be_error()
   case result {
-    Error(reason) ->
+    Error(client.RequestError(message: reason)) ->
       string.contains(reason, "Ambiguous recording match") |> should.be_true()
+    Error(client.ResponseError(_)) -> should.fail()
     Ok(_) -> should.fail()
   }
+
+  // Cleanup
+  recorder.stop(playback_rec) |> result.unwrap(Nil)
+}
+
+pub fn playback_of_error_recording_preserves_status_and_headers_test() {
+  // Arrange - Create a recording with error status and headers
+  let recordings_directory_path = test_recording_directory()
+  let assert Ok(rec) =
+    recorder.new()
+    |> directory(recordings_directory_path)
+    |> mode("record")
+    |> start()
+
+  let test_request =
+    recording.RecordedRequest(
+      method: http.Get,
+      scheme: http.Http,
+      host: "localhost",
+      port: option.Some(9876),
+      path: "/not-found",
+      query: option.None,
+      headers: [],
+      body: "",
+    )
+  let test_response =
+    recording.BlockingResponse(
+      status: 404,
+      headers: [#("Content-Type", "application/json"), #("X-Custom", "test")],
+      body: "not found",
+    )
+  let test_recording =
+    recording.Recording(request: test_request, response: test_response)
+  recorder.add_recording(rec, test_recording)
+  recorder.stop(rec) |> result.unwrap(Nil)
+
+  // Start playback
+  let assert Ok(playback_rec) =
+    recorder.new()
+    |> directory(recordings_directory_path)
+    |> mode("playback")
+    |> start()
+
+  let request =
+    mock_request("/not-found")
+    |> client.recorder(playback_rec)
+
+  // Act
+  let result = client.send(request)
+
+  // Assert - Error with correct status, headers converted to Header type, and body
+  case result {
+    Error(client.ResponseError(response: client.HttpResponse(
+      status: status,
+      headers: headers,
+      body: body,
+    ))) -> {
+      status |> should.equal(404)
+      body |> should.equal("not found")
+      // Headers should be converted from tuples to Header type
+      let has_content_type =
+        list.any(headers, fn(h: client.Header) {
+          h.name == "Content-Type" && h.value == "application/json"
+        })
+      has_content_type |> should.be_true()
+      let has_custom =
+        list.any(headers, fn(h: client.Header) {
+          h.name == "X-Custom" && h.value == "test"
+        })
+      has_custom |> should.be_true()
+    }
+    Error(client.RequestError(message: msg)) -> {
+      io.println("Expected ResponseError, got RequestError: " <> msg)
+      should.fail()
+    }
+    Ok(_) -> {
+      io.println("Expected error for 404 playback, got Ok")
+      should.fail()
+    }
+  }
+
+  // Cleanup
+  recorder.stop(playback_rec) |> result.unwrap(Nil)
+}
+
+pub fn playback_of_success_recording_preserves_status_and_headers_test() {
+  // Arrange - Create a recording with success status and headers
+  let recordings_directory_path = test_recording_directory()
+  let assert Ok(rec) =
+    recorder.new()
+    |> directory(recordings_directory_path)
+    |> mode("record")
+    |> start()
+
+  let test_request =
+    recording.RecordedRequest(
+      method: http.Get,
+      scheme: http.Http,
+      host: "localhost",
+      port: option.Some(9876),
+      path: "/api",
+      query: option.None,
+      headers: [],
+      body: "",
+    )
+  let test_response =
+    recording.BlockingResponse(
+      status: 200,
+      headers: [#("Content-Type", "text/plain"), #("X-Request-Id", "abc123")],
+      body: "ok",
+    )
+  let test_recording =
+    recording.Recording(request: test_request, response: test_response)
+  recorder.add_recording(rec, test_recording)
+  recorder.stop(rec) |> result.unwrap(Nil)
+
+  // Start playback
+  let assert Ok(playback_rec) =
+    recorder.new()
+    |> directory(recordings_directory_path)
+    |> mode("playback")
+    |> start()
+
+  let request =
+    mock_request("/api")
+    |> client.recorder(playback_rec)
+
+  // Act
+  let assert Ok(client.HttpResponse(
+    status: status,
+    headers: headers,
+    body: body,
+  )) = client.send(request)
+
+  // Assert - All fields preserved
+  status |> should.equal(200)
+  body |> should.equal("ok")
+  let has_request_id =
+    list.any(headers, fn(h: client.Header) {
+      h.name == "X-Request-Id" && h.value == "abc123"
+    })
+  has_request_id |> should.be_true()
 
   // Cleanup
   recorder.stop(playback_rec) |> result.unwrap(Nil)
@@ -848,11 +1010,191 @@ pub fn playback_from_committed_fixtures_returns_recorded_response_test() {
   // Act - Make request that matches committed fixture
   let request = mock_request("/text") |> client.recorder(rec)
 
-  let assert Ok(body) = client.send(request)
+  let assert Ok(client.HttpResponse(body: body, ..)) = client.send(request)
 
   // Assert - Should get FIXTURE response, not real mock server response
   // Mock server returns "Hello, World!" but fixture has different content
   body |> should.equal("FIXTURE_RESPONSE_NO_NETWORK")
+
+  // Cleanup
+  recorder.stop(rec) |> result.unwrap(Nil)
+}
+
+pub fn start_stream_playback_with_streaming_response_calls_callbacks_test() {
+  // Arrange - save a streaming response recording directly to disk
+  let recordings_directory_path =
+    temp_directory("start_stream_playback_streaming")
+
+  let test_request =
+    recording.RecordedRequest(
+      method: http.Get,
+      scheme: http.Http,
+      host: "localhost",
+      port: option.Some(9876),
+      path: "/stream",
+      query: option.None,
+      headers: [],
+      body: "",
+    )
+  let chunk1 = recording.Chunk(data: <<"hello ":utf8>>, delay_ms: 0)
+  let chunk2 = recording.Chunk(data: <<"world":utf8>>, delay_ms: 0)
+  let test_response =
+    recording.StreamingResponse(
+      status: 200,
+      headers: [#("Content-Type", "text/event-stream")],
+      chunks: [chunk1, chunk2],
+    )
+  let test_recording =
+    recording.Recording(request: test_request, response: test_response)
+  let key_fn =
+    matching.request_key(method: True, url: True, headers: False, body: False)
+  let assert Ok(_) =
+    storage.save_recording_immediately(
+      recordings_directory_path,
+      test_recording,
+      key_fn(test_request),
+    )
+
+  // Start in playback mode
+  let assert Ok(playback_rec) =
+    recorder.new()
+    |> directory(recordings_directory_path)
+    |> mode("playback")
+    |> start()
+
+  // Set up subjects to collect callback data
+  let start_subject = process.new_subject()
+  let chunks_subject = process.new_subject()
+  let end_subject = process.new_subject()
+
+  let request =
+    mock_request("/stream")
+    |> client.recorder(playback_rec)
+    |> client.on_stream_start(fn(headers) {
+      process.send(start_subject, headers)
+    })
+    |> client.on_stream_chunk(fn(data) { process.send(chunks_subject, data) })
+    |> client.on_stream_end(fn(_headers) { process.send(end_subject, True) })
+
+  // Act
+  let assert Ok(handle) = client.start_stream(request)
+  client.await_stream(handle)
+
+  // Assert - on_stream_start was called with headers
+  let assert Ok(start_headers) = process.receive(start_subject, 1000)
+  let has_content_type =
+    list.any(start_headers, fn(h: client.Header) {
+      h.name == "Content-Type" && h.value == "text/event-stream"
+    })
+  has_content_type |> should.be_true()
+
+  // Assert - on_stream_chunk was called with correct data
+  let chunk_data = collect_chunks_from_mailbox(chunks_subject, [])
+  let combined =
+    chunk_data
+    |> list.map(fn(d) { bit_array.to_string(d) |> result.unwrap("") })
+    |> string.join("")
+  combined |> should.equal("hello world")
+
+  // Assert - on_stream_end was called
+  let assert Ok(True) = process.receive(end_subject, 1000)
+
+  // Cleanup
+  recorder.stop(playback_rec) |> result.unwrap(Nil)
+}
+
+pub fn start_stream_playback_with_blocking_response_sends_body_as_single_chunk_test() {
+  // Arrange - save a blocking response recording directly to disk
+  let recordings_directory_path =
+    temp_directory("start_stream_playback_blocking")
+
+  let test_request =
+    recording.RecordedRequest(
+      method: http.Get,
+      scheme: http.Http,
+      host: "localhost",
+      port: option.Some(9876),
+      path: "/text",
+      query: option.None,
+      headers: [],
+      body: "",
+    )
+  let test_response =
+    recording.BlockingResponse(
+      status: 200,
+      headers: [#("Content-Type", "text/plain")],
+      body: "Hello, World!",
+    )
+  let test_recording =
+    recording.Recording(request: test_request, response: test_response)
+  let key_fn =
+    matching.request_key(method: True, url: True, headers: False, body: False)
+  let assert Ok(_) =
+    storage.save_recording_immediately(
+      recordings_directory_path,
+      test_recording,
+      key_fn(test_request),
+    )
+
+  // Start in playback mode
+  let assert Ok(playback_rec) =
+    recorder.new()
+    |> directory(recordings_directory_path)
+    |> mode("playback")
+    |> start()
+
+  // Set up subjects to collect callback data
+  let chunks_subject = process.new_subject()
+  let end_subject = process.new_subject()
+
+  let request =
+    mock_request("/text")
+    |> client.recorder(playback_rec)
+    |> client.on_stream_chunk(fn(data) { process.send(chunks_subject, data) })
+    |> client.on_stream_end(fn(_headers) { process.send(end_subject, True) })
+
+  // Act
+  let assert Ok(handle) = client.start_stream(request)
+  client.await_stream(handle)
+
+  // Assert - on_stream_chunk was called with the full body
+  let chunk_data = collect_chunks_from_mailbox(chunks_subject, [])
+  let combined =
+    chunk_data
+    |> list.map(fn(d) { bit_array.to_string(d) |> result.unwrap("") })
+    |> string.join("")
+  combined |> should.equal("Hello, World!")
+
+  // Assert - on_stream_end was called
+  let assert Ok(True) = process.receive(end_subject, 1000)
+
+  // Cleanup
+  recorder.stop(playback_rec) |> result.unwrap(Nil)
+}
+
+pub fn start_stream_with_recorder_not_finding_recording_uses_real_stream_test() {
+  // Arrange - empty playback directory (no recordings)
+  let recordings_directory_path = temp_directory("start_stream_playback_miss")
+  let assert Ok(rec) =
+    recorder.new()
+    |> directory(recordings_directory_path)
+    |> mode("playback")
+    |> start()
+
+  let chunks_subject = process.new_subject()
+
+  let request =
+    mock_request("/stream/fast")
+    |> client.recorder(rec)
+    |> client.on_stream_chunk(fn(data) { process.send(chunks_subject, data) })
+
+  // Act
+  let assert Ok(handle) = client.start_stream(request)
+  client.await_stream(handle)
+
+  // Assert - should fall back to real request when no recording found
+  let chunks = collect_chunks_from_mailbox(chunks_subject, [])
+  { chunks != [] } |> should.be_true()
 
   // Cleanup
   recorder.stop(rec) |> result.unwrap(Nil)

--- a/modules/http_client/test/recorder_test.gleam
+++ b/modules/http_client/test/recorder_test.gleam
@@ -1,4 +1,4 @@
-import dream_http_client/recorder.{directory, mode, start}
+import dream_http_client/recorder.{directory, mode, response_transformer, start}
 import dream_http_client/recording
 import dream_http_client/storage
 import gleam/erlang/process
@@ -392,4 +392,101 @@ pub fn playback_errors_on_ambiguous_key_collision_test() {
   recorder.find_recording(playback, base.request) |> should.be_error()
 
   recorder.stop(playback) |> result.unwrap(Nil)
+}
+
+pub fn transform_response_applies_transformer_function_test() {
+  // Arrange - Create a recorder with a response transformer that scrubs the body
+  let recordings_directory_path = temp_directory("transform_response_direct")
+  let assert Ok(rec) =
+    recorder.new()
+    |> directory(recordings_directory_path)
+    |> mode("record")
+    |> response_transformer(
+      fn(
+        _request: recording.RecordedRequest,
+        response: recording.RecordedResponse,
+      ) -> recording.RecordedResponse {
+        case response {
+          recording.BlockingResponse(status, headers, _body) ->
+            recording.BlockingResponse(
+              status: status,
+              headers: headers,
+              body: "SCRUBBED",
+            )
+          other -> other
+        }
+      },
+    )
+    |> start()
+
+  let test_request =
+    recording.RecordedRequest(
+      method: http.Get,
+      scheme: http.Http,
+      host: "localhost",
+      port: option.Some(9876),
+      path: "/text",
+      query: option.None,
+      headers: [],
+      body: "",
+    )
+  let original_response =
+    recording.BlockingResponse(
+      status: 200,
+      headers: [#("Content-Type", "text/plain")],
+      body: "secret data",
+    )
+
+  // Act - Call transform_response directly
+  let transformed =
+    recorder.transform_response(rec, test_request, original_response)
+
+  // Assert - Body was scrubbed by the transformer
+  case transformed {
+    recording.BlockingResponse(_status, _headers, body) ->
+      body |> should.equal("SCRUBBED")
+    _ -> should.fail()
+  }
+
+  // Cleanup
+  recorder.stop(rec) |> result.unwrap(Nil)
+}
+
+pub fn transform_response_without_transformer_returns_original_test() {
+  // Arrange - Create a recorder with NO response transformer
+  let recordings_directory_path =
+    temp_directory("transform_response_no_transformer")
+  let assert Ok(rec) =
+    recorder.new()
+    |> directory(recordings_directory_path)
+    |> mode("record")
+    |> start()
+
+  let test_request =
+    recording.RecordedRequest(
+      method: http.Get,
+      scheme: http.Http,
+      host: "localhost",
+      port: option.Some(9876),
+      path: "/text",
+      query: option.None,
+      headers: [],
+      body: "",
+    )
+  let original_response =
+    recording.BlockingResponse(status: 200, headers: [], body: "untouched data")
+
+  // Act - Call transform_response directly (no transformer configured)
+  let transformed =
+    recorder.transform_response(rec, test_request, original_response)
+
+  // Assert - Response is returned unchanged
+  case transformed {
+    recording.BlockingResponse(_status, _headers, body) ->
+      body |> should.equal("untouched data")
+    _ -> should.fail()
+  }
+
+  // Cleanup
+  recorder.stop(rec) |> result.unwrap(Nil)
 }

--- a/modules/http_client/test/snippets/blocking_request.gleam
+++ b/modules/http_client/test/snippets/blocking_request.gleam
@@ -4,10 +4,12 @@
 ////
 //// Note: README shows api.example.com, but tests use localhost:9876 (mock server)
 
-import dream_http_client/client.{host, method, path, port, scheme, send}
+import dream_http_client/client.{
+  type HttpResponse, type SendError, host, method, path, port, scheme, send,
+}
 import gleam/http
 
-pub fn simple_get() -> Result(String, String) {
+pub fn simple_get() -> Result(HttpResponse, SendError) {
   client.new()
   |> method(http.Get)
   |> scheme(http.Http)

--- a/modules/http_client/test/snippets/post_json.gleam
+++ b/modules/http_client/test/snippets/post_json.gleam
@@ -5,12 +5,13 @@
 //// Note: README shows api.example.com, but tests use localhost:9876 (mock server)
 
 import dream_http_client/client.{
-  add_header, body, host, method, path, port, scheme, send,
+  type HttpResponse, type SendError, add_header, body, host, method, path, port,
+  scheme, send,
 }
 import gleam/http
 import gleam/json
 
-pub fn post_user() -> Result(String, String) {
+pub fn post_user() -> Result(HttpResponse, SendError) {
   let user_json =
     json.object([
       #("name", json.string("Alice")),

--- a/modules/http_client/test/snippets/recording_basic.gleam
+++ b/modules/http_client/test/snippets/recording_basic.gleam
@@ -5,7 +5,7 @@
 //// Note: Tests use localhost:9876 (mock server) instead of external APIs
 
 import dream_http_client/client.{
-  host, path, port, recorder as with_recorder, scheme, send,
+  HttpResponse, host, path, port, recorder as with_recorder, scheme, send,
 }
 import dream_http_client/recorder.{directory, mode, start}
 import gleam/http
@@ -38,7 +38,9 @@ pub fn record_and_playback() -> Result(Bool, String) {
   // Recording is saved immediately, stop is optional
   let _ = recorder.stop(rec)
 
-  use original_body <- result.try(request_result)
+  use HttpResponse(body: original_body, ..) <- result.try(
+    request_result |> result.map_error(fn(_) { "Request failed" }),
+  )
 
   // 2. Playback from recording (no network call)
   use playback_rec <- result.try(
@@ -59,7 +61,9 @@ pub fn record_and_playback() -> Result(Bool, String) {
 
   let _ = recorder.stop(playback_rec)
 
-  use playback_body <- result.try(playback_result)
+  use HttpResponse(body: playback_body, ..) <- result.try(
+    playback_result |> result.map_error(fn(_) { "Playback failed" }),
+  )
 
   // Cleanup
   let _ = simplifile.delete(recordings_directory_path)

--- a/modules/http_client/test/snippets/recording_playback.gleam
+++ b/modules/http_client/test/snippets/recording_playback.gleam
@@ -3,7 +3,8 @@
 //// Example showing how to use playback mode for testing without external dependencies.
 
 import dream_http_client/client.{
-  host, path, port, recorder as with_recorder, scheme, send,
+  type HttpResponse, type SendError, host, path, port, recorder as with_recorder,
+  scheme, send,
 }
 import dream_http_client/recorder.{directory, mode, start}
 import dream_http_client/recording
@@ -12,7 +13,7 @@ import gleam/option
 import gleam/result
 import simplifile
 
-pub fn test_with_playback() -> Result(String, String) {
+pub fn test_with_playback() -> Result(HttpResponse, SendError) {
   // First record a request to create the fixture
   let recordings_directory_path = "build/test_playback_snippet"
 
@@ -43,7 +44,8 @@ pub fn test_with_playback() -> Result(String, String) {
     recorder.new()
     |> directory(recordings_directory_path)
     |> mode("record")
-    |> start(),
+    |> start()
+    |> result.map_error(fn(e) { client.RequestError(message: e) }),
   )
 
   recorder.add_recording(rec, test_recording)
@@ -54,7 +56,8 @@ pub fn test_with_playback() -> Result(String, String) {
     recorder.new()
     |> directory(recordings_directory_path)
     |> mode("playback")
-    |> start(),
+    |> start()
+    |> result.map_error(fn(e) { client.RequestError(message: e) }),
   )
 
   // Make request - returns recorded response without network call

--- a/modules/http_client/test/snippets/recording_start_stream.gleam
+++ b/modules/http_client/test/snippets/recording_start_stream.gleam
@@ -1,0 +1,103 @@
+//// Recording and Playback with start_stream()
+////
+//// Example showing how to record a streaming response and play it back
+//// using the callback-based streaming API.
+////
+//// Note: Tests use localhost:9876 (mock server) instead of external APIs
+
+import dream_http_client/client.{
+  await_stream, host, on_stream_chunk, on_stream_end, on_stream_start, path,
+  port, recorder as with_recorder, scheme, start_stream,
+}
+import dream_http_client/recorder.{directory, mode, start}
+import gleam/bit_array
+import gleam/erlang/process
+import gleam/http
+import gleam/result
+import simplifile
+
+pub fn record_and_playback_start_stream() -> Result(Bool, String) {
+  let recordings_directory_path = "build/test_recordings_start_stream_snippet"
+
+  // Clean up from previous runs
+  let _ = simplifile.delete(recordings_directory_path)
+
+  // 1. Record a real streaming request
+  use rec <- result.try(
+    recorder.new()
+    |> directory(recordings_directory_path)
+    |> mode("record")
+    |> start(),
+  )
+
+  let record_subject = process.new_subject()
+
+  use record_handle <- result.try(
+    client.new()
+    |> scheme(http.Http)
+    |> host("localhost")
+    |> port(9876)
+    |> path("/stream/fast")
+    |> with_recorder(rec)
+    |> on_stream_start(fn(_headers) { Nil })
+    |> on_stream_chunk(fn(data) {
+      process.send(record_subject, bit_array.byte_size(data))
+    })
+    |> on_stream_end(fn(_headers) { process.send(record_subject, -1) })
+    |> start_stream(),
+  )
+
+  await_stream(record_handle)
+  let _ = recorder.stop(rec)
+
+  let original_bytes = collect_sizes(record_subject, 0)
+
+  case original_bytes > 0 {
+    True -> Nil
+    False -> panic as "No bytes received during recording"
+  }
+
+  // 2. Playback from recording (no network call)
+  use playback_rec <- result.try(
+    recorder.new()
+    |> directory(recordings_directory_path)
+    |> mode("playback")
+    |> start(),
+  )
+
+  let playback_subject = process.new_subject()
+
+  use playback_handle <- result.try(
+    client.new()
+    |> scheme(http.Http)
+    |> host("localhost")
+    |> port(9876)
+    |> path("/stream/fast")
+    |> with_recorder(playback_rec)
+    |> on_stream_start(fn(_headers) { Nil })
+    |> on_stream_chunk(fn(data) {
+      process.send(playback_subject, bit_array.byte_size(data))
+    })
+    |> on_stream_end(fn(_headers) { process.send(playback_subject, -1) })
+    |> start_stream(),
+  )
+
+  await_stream(playback_handle)
+  let _ = recorder.stop(playback_rec)
+
+  let playback_bytes = collect_sizes(playback_subject, 0)
+
+  // Cleanup
+  let _ = simplifile.delete(recordings_directory_path)
+
+  // Verify playback returned data
+  Ok(playback_bytes > 0 && playback_bytes == original_bytes)
+}
+
+fn collect_sizes(subject: process.Subject(Int), total: Int) -> Int {
+  case process.receive(subject, 1000) {
+    Ok(-1) -> total
+    Ok(size) -> collect_sizes(subject, total + size)
+    Error(_) -> total
+  }
+}

--- a/modules/http_client/test/snippets/recording_stream_yielder.gleam
+++ b/modules/http_client/test/snippets/recording_stream_yielder.gleam
@@ -1,0 +1,84 @@
+//// Recording and Playback with stream_yielder()
+////
+//// Example showing how to record a streaming response and play it back
+//// using the yielder-based streaming API.
+////
+//// Note: Tests use localhost:9876 (mock server) instead of external APIs
+
+import dream_http_client/client.{
+  host, path, port, recorder as with_recorder, scheme, stream_yielder,
+}
+import dream_http_client/recorder.{directory, mode, start}
+import gleam/bytes_tree
+import gleam/http
+import gleam/result
+import gleam/yielder
+import simplifile
+
+pub fn record_and_playback_stream_yielder() -> Result(Bool, String) {
+  let recordings_directory_path = "build/test_recordings_stream_yielder_snippet"
+
+  // Clean up from previous runs
+  let _ = simplifile.delete(recordings_directory_path)
+
+  // 1. Record a real streaming request
+  use rec <- result.try(
+    recorder.new()
+    |> directory(recordings_directory_path)
+    |> mode("record")
+    |> start(),
+  )
+
+  let original_bytes =
+    client.new()
+    |> scheme(http.Http)
+    |> host("localhost")
+    |> port(9876)
+    |> path("/stream/fast")
+    |> with_recorder(rec)
+    |> stream_yielder()
+    |> yielder.fold(0, fn(total, chunk_result) {
+      case chunk_result {
+        Ok(chunk) -> total + bytes_tree.byte_size(chunk)
+        Error(_) -> total
+      }
+    })
+
+  let _ = recorder.stop(rec)
+
+  case original_bytes > 0 {
+    True -> Nil
+    False -> panic as "No bytes received during recording"
+  }
+
+  // 2. Playback from recording (no network call)
+  use playback_rec <- result.try(
+    recorder.new()
+    |> directory(recordings_directory_path)
+    |> mode("playback")
+    |> start(),
+  )
+
+  let playback_bytes =
+    client.new()
+    |> scheme(http.Http)
+    |> host("localhost")
+    |> port(9876)
+    |> path("/stream/fast")
+    |> with_recorder(playback_rec)
+    |> stream_yielder()
+    |> yielder.fold(0, fn(total, chunk_result) {
+      case chunk_result {
+        Ok(chunk) -> total + bytes_tree.byte_size(chunk)
+        Error(_) -> total
+      }
+    })
+
+  let _ = recorder.stop(playback_rec)
+
+  // Cleanup
+  let _ = simplifile.delete(recordings_directory_path)
+
+  // Verify playback returned data
+  Ok(playback_bytes > 0 && playback_bytes == original_bytes)
+}

--- a/modules/http_client/test/snippets/request_builder.gleam
+++ b/modules/http_client/test/snippets/request_builder.gleam
@@ -5,12 +5,13 @@
 //// Note: README shows api.example.com, but tests use localhost:9876
 
 import dream_http_client/client.{
-  add_header, body, host, method, path, port, query, scheme, send, timeout,
+  type HttpResponse, type SendError, add_header, body, host, method, path, port,
+  query, scheme, send, timeout,
 }
 import gleam/http
 import gleam/json
 
-pub fn build_complex_request() -> Result(String, String) {
+pub fn build_complex_request() -> Result(HttpResponse, SendError) {
   let json_body =
     json.object([#("query", json.string("test")), #("limit", json.int(10))])
 

--- a/modules/http_client/test/snippets/timeout_config.gleam
+++ b/modules/http_client/test/snippets/timeout_config.gleam
@@ -4,10 +4,12 @@
 ////
 //// Note: README shows api.example.com, but tests use localhost:9876
 
-import dream_http_client/client.{host, path, port, scheme, send, timeout}
+import dream_http_client/client.{
+  type HttpResponse, type SendError, host, path, port, scheme, send, timeout,
+}
 import gleam/http
 
-pub fn short_timeout() -> Result(String, String) {
+pub fn short_timeout() -> Result(HttpResponse, SendError) {
   // Short timeout for quick APIs
   client.new()
   |> scheme(http.Http)

--- a/modules/http_client/test/snippets_test.gleam
+++ b/modules/http_client/test/snippets_test.gleam
@@ -3,6 +3,7 @@
 //// This ensures the snippet code examples are valid and work correctly.
 //// We use dream_mock_server (localhost:9876) to avoid external dependencies.
 
+import dream_http_client/client
 import dream_http_client/recording
 import gleam/http
 import gleam/option
@@ -14,6 +15,8 @@ import snippets/recording_ambiguous_match
 import snippets/recording_basic
 import snippets/recording_playback
 import snippets/recording_response_transformer
+import snippets/recording_start_stream
+import snippets/recording_stream_yielder
 import snippets/recording_transformer
 import snippets/request_builder
 import snippets/stream_cancel
@@ -96,9 +99,9 @@ pub fn matching_config_custom_test() {
 }
 
 pub fn recording_playback_test() {
-  recording_playback.test_with_playback()
-  |> should.be_ok()
-  |> should.equal("Test data")
+  let assert Ok(client.HttpResponse(body: body, ..)) =
+    recording_playback.test_with_playback()
+  body |> should.equal("Test data")
 }
 
 pub fn recording_transformer_test() {
@@ -126,6 +129,18 @@ pub fn stream_messages_basic_test() {
 
 pub fn stream_cancel_test() {
   stream_cancel.cancel_stream()
+  |> should.be_ok()
+  |> should.equal(True)
+}
+
+pub fn recording_stream_yielder_test() {
+  recording_stream_yielder.record_and_playback_stream_yielder()
+  |> should.be_ok()
+  |> should.equal(True)
+}
+
+pub fn recording_start_stream_test() {
+  recording_start_stream.record_and_playback_start_stream()
   |> should.be_ok()
   |> should.equal(True)
 }

--- a/modules/opensearch/CHANGELOG.md
+++ b/modules/opensearch/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `dream_opensearch` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.0 - 2026-02-16
+
+### Changed
+
+- Updated to `dream_http_client` 5.0.0.
+- `send_request` now properly routes HTTP error responses (4xx/5xx) to `Error(body)` instead of `Ok(body)`. The error string contains the response body, which typically includes error details from OpenSearch.
+- Updated dependency constraint: `dream_http_client >= 5.0.0 and < 6.0.0`.
+
+## 2.0.0
+
+### Breaking Changes
+
+- Bumped to match dream_http_client 4.x API changes.
+
 ## 1.0.2 - 2025-11-21
 
 ### Changed

--- a/modules/opensearch/gleam.toml
+++ b/modules/opensearch/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream_opensearch"
-version = "2.0.0"
+version = "2.1.0"
 description = "Simple OpenSearch client for Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }
@@ -12,7 +12,7 @@ links = [
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 gleam_json = ">= 2.0.0 and < 4.0.0"
 gleam_http = ">= 4.3.0 and < 5.0.0"
-dream_http_client = ">= 2.1.0 and < 3.0.0"
+dream_http_client = { path = "../http_client" }
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/modules/opensearch/manifest.toml
+++ b/modules/opensearch/manifest.toml
@@ -2,8 +2,9 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "dream_http_client", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_yielder", "simplifile"], otp_app = "dream_http_client", source = "hex", outer_checksum = "CB48E7A808D7F6A00B8A57C480A7D2C1051560F4616F9DF8297B22D3B9284B4A" },
+  { name = "dream_http_client", version = "5.0.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_yielder", "simplifile"], source = "local", path = "../http_client" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_http", version = "4.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "82EA6A717C842456188C190AFB372665EA56CE13D8559BF3B1DD9E40F619EE0C" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
@@ -11,11 +12,11 @@ packages = [
   { name = "gleam_stdlib", version = "0.67.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "6368313DB35963DC02F677A513BB0D95D58A34ED0A9436C8116820BF94BE3511" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
   { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
-  { name = "simplifile", version = "2.3.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "957E0E5B75927659F1D2A1B7B75D7B9BA96FAA8D0C53EA71C4AD9CD0C6B848F6" },
+  { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
 ]
 
 [requirements]
-dream_http_client = { version = ">= 2.1.0 and < 3.0.0" }
+dream_http_client = { path = "../http_client" }
 gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
 gleam_json = { version = ">= 2.0.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }

--- a/modules/opensearch/src/dream_opensearch/client.gleam
+++ b/modules/opensearch/src/dream_opensearch/client.gleam
@@ -92,8 +92,8 @@ pub fn new(base_url: String) -> Client {
 ///
 /// ## Returns
 ///
-/// - `Ok(String)`: The response body as a string
-/// - `Error(String)`: An error message if the request failed
+/// - `Ok(String)`: The response body as a string (status < 400)
+/// - `Error(String)`: The error response body (status >= 400) or an error message for connection failures
 ///
 /// ## Example
 ///
@@ -119,7 +119,7 @@ pub fn send_request(
   let #(scheme, host, port, path_part) = parse_url(url)
 
   let base_request =
-    http_client.new
+    http_client.new()
     |> http_client.method(method)
     |> http_client.scheme(scheme)
     |> http_client.host(host)
@@ -132,7 +132,14 @@ pub fn send_request(
     None -> base_request
   }
 
-  http_client.send(request)
+  case http_client.send(request) {
+    Ok(http_client.HttpResponse(body: body, ..)) -> Ok(body)
+    Error(http_client.ResponseError(response: http_client.HttpResponse(
+      body: body,
+      ..,
+    ))) -> Error(body)
+    Error(http_client.RequestError(message: message)) -> Error(message)
+  }
 }
 
 fn parse_url(url: String) -> #(http.Scheme, String, Option(Int), String) {

--- a/test/fixtures/hooks.gleam
+++ b/test/fixtures/hooks.gleam
@@ -54,8 +54,8 @@ fn is_server_responding() -> Bool {
 
   case result {
     Ok(_response) -> True
-    // Connection refused or timeout expected during startup polling
-    Error(_connection_error) -> False
+    // Connection refused, timeout, or HTTP error expected during startup polling
+    Error(_error) -> False
   }
 }
 


### PR DESCRIPTION
## Summary

- **`send()` returns `HttpResponse`** — status, headers, and body instead of just the body string
- **Typed error variants** — `ResponseError` for HTTP 4xx/5xx (with full response), `RequestError` for transport failures
- **`Ok` always means success** — HTTP error responses moved from `Ok` to `Error`, eliminating silent failures
- **`start_stream()` playback support** — all three execution modes (`send()`, `stream_yielder()`, `start_stream()`) now fully support recording and playback
- **Bug fix** — `dream_opensearch` updated from pre-4.0 `client.new` to `client.new()`

## Breaking Changes

- `send()` return type: `Result(String, String)` → `Result(HttpResponse, SendError)`
- HTTP 4xx/5xx responses: `Ok(body)` → `Error(ResponseError(response))`
- Transport errors: `Error(message)` → `Error(RequestError(message: message))`

## Test Coverage

All 134 tests pass. See [release notes](https://github.com/TrustBound/dream/blob/develop/modules/http_client/releases/release-5.0.0.md) for full details.