### PR TITLE
HTTP Client Release 5.1.0: Compression support and streaming error resilience

### DIFF
--- a/modules/http_client/CHANGELOG.md
+++ b/modules/http_client/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to `dream_http_client` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.1.0 - 2026-02-28
+
+### Added
+
+- **Transparent gzip/deflate decompression for all HTTP client modes.** The client now
+  automatically sends `Accept-Encoding: gzip, deflate` and decompresses response bodies
+  when the server returns `Content-Encoding: gzip` or `Content-Encoding: deflate`.
+  This works across all three execution modes:
+  - `send()` — synchronous responses are decompressed before returning
+  - `start_stream()` — streamed chunks are decompressed on-the-fly via zlib inflate
+  - `stream_yielder()` — streamed chunks are decompressed on-the-fly via zlib inflate
+- **User-set `Accept-Encoding` headers are preserved.** If you explicitly set an
+  `Accept-Encoding` header on a request, the client will not inject its own — your
+  header takes precedence.
+- **Unrecognized encodings are passed through with a warning.** If a server returns
+  an encoding the client does not support (e.g., `br`, `zstd`), the raw bytes are
+  passed through unchanged and a warning is logged. The client does not crash.
+- **Corrupted compressed data is handled gracefully.** If decompression fails (e.g.,
+  corrupted gzip data), the raw bytes are passed through with a warning instead of
+  crashing the process.
+- **24 new compression tests** covering the full permutation matrix of encoding type
+  (gzip, deflate, identity, none, unknown, corrupted) x request mode (send, start_stream,
+  stream_yielder), header injection behavior, and zlib lifecycle cleanup.
+- **10 new streaming regression tests** for the non-streaming response bug fix (see Fixed below).
+
+### Fixed
+
+- **Streaming requests no longer crash when upstream returns a non-streaming error response.**
+  When a streaming HTTP request (`start_stream()` / `stream_yielder()`) hit an endpoint that
+  returned a complete HTTP error (e.g., 401, 403, 429, 500 with a JSON body) instead of starting
+  an SSE stream, Erlang's `httpc` sent a complete response message that was unhandled.
+  `decode_stream_message_for_selector` crashed with `error(badarg)`, killing the stream process
+  and causing a 504 timeout. The `on_stream_error` callback was never invoked, and the upstream
+  error details (status code, response body) were lost entirely.
+- **All four streaming code paths now handle complete response messages:**
+  - `decode_stream_message_for_selector/1` — was crashing with `error(badarg)`, now routes to `stream_error`
+  - `receive_stream_message/1` — was timing out silently, now returns `stream_error` with status and body
+  - `stream_owner_wait/5` — was silently discarding the message via `_Other` catchall, now buffers the error
+  - `stream_owner_next_message/2` — was recursing forever via `_Other` catchall, now returns the error
+- **Error messages include HTTP status code and response body.** The `on_stream_error` callback
+  (and `stream_yielder` `Error` results) now receive a formatted message like
+  `"HTTP 401 Unauthorized: {\"error\":{\"message\":\"Invalid API key\"}}"` instead of crashing
+  or timing out.
+
 ## 5.0.0 - 2026-02-16
 
 ### Breaking Changes

--- a/modules/http_client/gleam.toml
+++ b/modules/http_client/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream_http_client"
-version = "5.0.0"
+version = "5.1.0"
 description = "Type-safe HTTP client for Gleam with streaming support"
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }

--- a/modules/http_client/releases/release-5.1.0.md
+++ b/modules/http_client/releases/release-5.1.0.md
@@ -1,0 +1,212 @@
+# dream_http_client v5.1.0
+
+**Release Date:** February 28, 2026
+
+This release adds transparent gzip/deflate decompression across all three HTTP
+client execution modes and fixes a high-severity bug where streaming requests
+crash when the upstream server returns a non-streaming HTTP error response.
+
+No API changes are required -- both the compression support and the bug fix are
+fully transparent.
+
+---
+
+## Feature: Transparent gzip/deflate compression
+
+The client now automatically handles compressed HTTP responses:
+
+1. Injects `Accept-Encoding: gzip, deflate` on every outgoing request (unless
+   you already set your own `Accept-Encoding` header)
+2. Detects `Content-Encoding: gzip` or `Content-Encoding: deflate` in responses
+3. Decompresses the body transparently before surfacing it to your code
+4. Strips the `Content-Encoding` header after successful decompression
+
+This applies to all three execution modes:
+- `send()` (synchronous) -- body is decompressed before return
+- `start_stream()` (callback-based) -- chunks are decompressed on-the-fly
+- `stream_yielder()` (pull-based) -- chunks are decompressed on-the-fly
+
+### Edge case handling
+
+- **`Content-Encoding: identity`** -- treated as a no-op (body passed through unchanged)
+- **Unrecognized encoding** (e.g. `br`, `zstd`) -- raw bytes passed through unchanged,
+  a warning is logged via `io:format`
+- **Corrupted compressed data** -- raw bytes passed through unchanged, a warning is logged
+- **User-provided `Accept-Encoding`** -- if you explicitly set this header, the client
+  will NOT inject its own. Your header takes precedence.
+
+### Implementation details
+
+All decompression is handled in the Erlang FFI shim (`dream_httpc_shim.erl`). The
+Gleam client code has zero changes -- this is entirely transparent.
+
+For streaming modes, zlib inflate contexts are initialized when `stream_start`
+arrives with a `Content-Encoding` header, used to decompress each chunk, and cleaned
+up when the stream ends or errors. The pull-based path (`stream_owner_wait`) threads
+the zlib context through process state; the message-based path
+(`decode_stream_message_for_selector`) stores it in the existing ETS ref mapping table.
+
+Window bits:
+- gzip: 31 (zlib + gzip header detection)
+- deflate: 15 (raw zlib wrapper)
+
+### Disabling compression
+
+If you need to disable automatic compression for a specific request, set your
+own `Accept-Encoding` header:
+
+```gleam
+client.new()
+|> client.headers([client.Header("Accept-Encoding", "identity")])
+|> client.send()
+```
+
+---
+
+## Bug Fix: Streaming crashes on non-streaming upstream responses
+
+When using `start_stream()` or `stream_yielder()` to make a streaming HTTP
+request, and the upstream responds with an HTTP error instead of starting an
+SSE stream, Erlang's `httpc` sends a complete response message rather than
+the expected `stream_start`/`stream`/`stream_end` sequence. This complete
+response tuple was unhandled in four locations in the Erlang FFI shim,
+causing crashes, hangs, or silent data loss depending on which code path
+was hit.
+
+In practice, this meant that every streaming request where the upstream
+returned an HTTP error (invalid API key, rate limit, server error) would
+either crash the stream process or hang indefinitely. The `on_stream_error`
+callback was never invoked, the caller timed out after 30 seconds with a
+504, and the actual upstream error details were lost entirely.
+
+### Bug details
+
+`httpc:request/4` with `{stream, self}` and `{sync, false}` can emit two
+classes of messages:
+
+**Streaming messages (handled in 5.0.0):**
+
+```erlang
+{http, {RequestId, stream_start, Headers}}
+{http, {RequestId, stream, BinBodyPart}}
+{http, {RequestId, stream_end, Headers}}
+{http, {RequestId, {error, Reason}}}
+```
+
+**Complete response message (NOT handled in 5.0.0):**
+
+```erlang
+{http, {RequestId, {{HttpVersion, StatusCode, ReasonPhrase}, Headers, Body}}}
+```
+
+### Affected code paths
+
+| Function | Behavior in 5.0.0 | Fixed in 5.1.0 |
+|:---------|:-------------------|:---------------|
+| `decode_stream_message_for_selector/1` | Crashed with `error(badarg)` | Routes to `stream_error` |
+| `receive_stream_message/1` | Timed out silently | Returns `stream_error` with status and body |
+| `stream_owner_wait/5` | Silently discarded message, process hung | Buffers error for delivery |
+| `stream_owner_next_message/2` | Recursed forever (infinite loop) | Returns error immediately |
+
+The complete response is now converted to a `stream_error` event with a formatted
+error message containing the HTTP status code and response body:
+
+```
+HTTP 401 Unauthorized: {"error":{"message":"Incorrect API key provided"}}
+```
+
+### Reproduction scenario
+
+Any streaming request where the upstream returns an HTTP error instead of
+starting a stream. Common examples:
+
+- Invalid API key to OpenAI (HTTP 401)
+- Rate limited by any API (HTTP 429)
+- Server error from upstream (HTTP 500)
+- Forbidden access (HTTP 403)
+
+```gleam
+let req = client.new()
+  |> client.method(http.Post)
+  |> client.scheme(http.Https)
+  |> client.host("api.openai.com")
+  |> client.path("/v1/chat/completions")
+  |> client.add_header("Authorization", "Bearer INVALID_KEY")
+  |> client.body("{\"model\":\"gpt-4o\",\"stream\":true,\"messages\":[{\"role\":\"user\",\"content\":\"hello\"}]}")
+  |> client.on_stream_error(fn(reason) { io.println("error: " <> reason) })
+
+// 5.0.0: crashes the stream process, caller times out
+// 5.1.0: on_stream_error fires with "HTTP 401 Unauthorized: {...}"
+let assert Ok(_handle) = client.start_stream(req)
+```
+
+---
+
+## Test coverage
+
+34 new tests total (168 tests pass across the entire suite):
+
+| Category | Count | Coverage |
+|----------|-------|----------|
+| Sync decompression (send) | 7 | gzip, deflate, identity, unknown, none, user header, corrupted |
+| Callback streaming (start_stream) | 4 | gzip, deflate, unknown, uncompressed |
+| Pull streaming (stream_yielder) | 4 | gzip, deflate, unknown, uncompressed |
+| Header injection | 6 | auto-inject x3 modes, preserve-custom x3 modes |
+| Zlib lifecycle cleanup | 3 | normal end x2, error cleanup |
+| Non-streaming response (start_stream) | 5 | 401, 500, status code check, body check, clean exit |
+| Non-streaming response (stream_yielder) | 3 | 401, 500, body check |
+| Regression guards | 2 | normal streaming still works |
+
+## Mock server additions
+
+New endpoints added to `dream_mock_server`:
+
+Non-streaming:
+- `GET /gzip` -- gzip-compressed response
+- `GET /deflate` -- deflate-compressed response
+- `GET /identity` -- `Content-Encoding: identity` response
+- `GET /unknown-encoding` -- `Content-Encoding: br` (simulates unsupported)
+- `GET /corrupted-gzip` -- garbage bytes with `Content-Encoding: gzip`
+- `GET /echo-accept-encoding` -- echoes the received `Accept-Encoding` header
+
+Streaming:
+- `GET /stream/gzip` -- gzip-compressed stream (5 chunks)
+- `GET /stream/deflate` -- deflate-compressed stream (5 chunks)
+- `GET /stream/unknown-encoding` -- raw stream with `Content-Encoding: br`
+
+## Upgrading
+
+Update your dependency:
+
+```toml
+[dependencies]
+dream_http_client = ">= 5.1.0 and < 6.0.0"
+```
+
+Then run:
+
+```bash
+gleam deps download
+```
+
+No breaking changes. All existing code works without modification. After
+upgrading, your HTTP client will automatically request and decompress
+gzip/deflate responses, and streaming requests to error-returning upstreams
+will fire `on_stream_error` instead of crashing.
+
+## Documentation
+
+- [dream_http_client hexdocs](https://hexdocs.pm/dream_http_client) -- v5.1.0
+- [README](https://github.com/TrustBound/dream/tree/main/modules/http_client)
+- [CHANGELOG](https://github.com/TrustBound/dream/blob/main/modules/http_client/CHANGELOG.md)
+
+## Community
+
+- [Full Documentation](https://github.com/TrustBound/dream/tree/main/modules/http_client)
+- [Discussions](https://github.com/TrustBound/dream/discussions)
+- [Report Issues](https://github.com/TrustBound/dream/issues)
+- [Contributing Guide](https://github.com/TrustBound/dream/blob/main/CONTRIBUTING.md)
+
+---
+
+**Full Changelog:** [CHANGELOG.md](https://github.com/TrustBound/dream/blob/main/modules/http_client/CHANGELOG.md)

--- a/modules/http_client/src/dream_http_client/dream_httpc_shim.erl
+++ b/modules/http_client/src/dream_http_client/dream_httpc_shim.erl
@@ -47,7 +47,7 @@ request_stream(Method, Url, Headers, Body, _Receiver, TimeoutMs) ->
     ok = configure_httpc(),
 
     NUrl = to_list(Url),
-    NHeaders = to_headers(Headers),
+    NHeaders = maybe_add_accept_encoding(to_headers(Headers)),
     Req = build_req(NUrl, NHeaders, Body),
     Owner = spawn(fun() -> stream_owner_loop(Method, Req, NUrl, TimeoutMs) end),
     {ok, Owner}.
@@ -135,10 +135,8 @@ stream_owner_loop(Method, Req, _Url, TimeoutMs) ->
     Opts = [{stream, self}, {sync, false}],
     case httpc:request(Method, Req, HttpOpts, Opts) of
         {ok, RequestId} ->
-            stream_owner_wait(RequestId, [], undefined, []);
+            stream_owner_wait(RequestId, [], undefined, [], undefined);
         Error ->
-            %% HTTP request failed to start - exit with error
-            %% fetch_next will detect the dead process and return an error
             exit({stream_start_failed, Error})
     end.
 
@@ -147,101 +145,106 @@ stream_owner_loop(Method, Req, _Url, TimeoutMs) ->
 %%   Buffer - queued {chunk, Bin}/{finished, Headers}/{error, Reason}
 %%   StartHeaders - normalized headers from stream_start (or undefined)
 %%   StartWaiters - callers waiting for stream_start headers
-stream_owner_wait(RequestId, Buffer, StartHeaders, StartWaiters) ->
+%%   ZlibCtx - zlib inflate context for decompression (undefined if none)
+stream_owner_wait(RequestId, Buffer, StartHeaders, StartWaiters, ZlibCtx) ->
     receive
         {fetch_next, From} ->
-            handle_fetch_next(From, RequestId, Buffer, StartHeaders, StartWaiters);
+            handle_fetch_next(From, RequestId, Buffer, StartHeaders, StartWaiters, ZlibCtx);
         {fetch_start_headers, From} ->
             case StartHeaders of
                 undefined ->
-                    %% Don't respond until we actually have stream_start headers.
-                    %% This makes fetch_start_headers a reliable way to capture
-                    %% response headers for recording.
-                    stream_owner_wait(RequestId, Buffer, StartHeaders, [From | StartWaiters]);
+                    stream_owner_wait(RequestId, Buffer, StartHeaders, [From | StartWaiters], ZlibCtx);
                 _ ->
                     From ! {stream_start_headers, normalize_headers_default(StartHeaders)},
-                    stream_owner_wait(RequestId, Buffer, StartHeaders, StartWaiters)
+                    stream_owner_wait(RequestId, Buffer, StartHeaders, StartWaiters, ZlibCtx)
             end;
         {http, {RequestId, stream, Bin}} ->
-            %% Buffer the chunk; we only emit on fetch_next to maintain pull model
-            stream_owner_wait(RequestId, Buffer ++ [{chunk, Bin}], StartHeaders, StartWaiters);
+            DecompBin = case ZlibCtx of
+                undefined -> Bin;
+                _ -> decompress_chunk(ZlibCtx, Bin)
+            end,
+            stream_owner_wait(RequestId, Buffer ++ [{chunk, DecompBin}], StartHeaders, StartWaiters, ZlibCtx);
         {http, {RequestId, stream_start, Headers}} ->
-            %% Record initial headers (normalized) for recorder usage
             Norm = normalize_headers(Headers),
             lists:foreach(fun(W) -> W ! {stream_start_headers, Norm} end, StartWaiters),
-            stream_owner_wait(RequestId, Buffer, Norm, []);
+            NewZlib = maybe_init_stream_zlib(Headers),
+            stream_owner_wait(RequestId, Buffer, Norm, [], NewZlib);
         {http, {RequestId, stream_start, Headers, _Pid}} ->
-            %% Some httpc versions include pid
             Norm = normalize_headers(Headers),
             lists:foreach(fun(W) -> W ! {stream_start_headers, Norm} end, StartWaiters),
-            stream_owner_wait(RequestId, Buffer, Norm, []);
+            NewZlib = maybe_init_stream_zlib(Headers),
+            stream_owner_wait(RequestId, Buffer, Norm, [], NewZlib);
         {http, {RequestId, stream_end, Headers}} ->
+            cleanup_zlib(ZlibCtx),
             stream_owner_wait(RequestId,
                               Buffer ++ [{finished, normalize_headers(Headers)}],
                               StartHeaders,
-                              StartWaiters);
+                              StartWaiters,
+                              undefined);
         {http, {RequestId, {error, Reason}}} ->
-            stream_owner_wait(RequestId, Buffer ++ [{error, Reason}], StartHeaders, StartWaiters);
+            cleanup_zlib(ZlibCtx),
+            stream_owner_wait(RequestId, Buffer ++ [{error, Reason}], StartHeaders, StartWaiters, undefined);
+        {http, {RequestId, {{_HttpVersion, StatusCode, ReasonPhrase}, _Headers, Body}}} ->
+            cleanup_zlib(ZlibCtx),
+            ErrorMsg = format_complete_response_error(StatusCode, ReasonPhrase, Body),
+            stream_owner_wait(RequestId, Buffer ++ [{error, ErrorMsg}], StartHeaders, StartWaiters, undefined);
         _Other ->
-            stream_owner_wait(RequestId, Buffer, StartHeaders, StartWaiters)
+            stream_owner_wait(RequestId, Buffer, StartHeaders, StartWaiters, ZlibCtx)
     end.
 
 %% Handle a fetch_next request from the client
-handle_fetch_next(From, RequestId, [], StartHeaders, StartWaiters) ->
+handle_fetch_next(From, RequestId, [], StartHeaders, StartWaiters, ZlibCtx) ->
     %% Buffer empty - fetch next message from stream
-    case stream_owner_next_message(RequestId) of
-        {start, _Hs} ->
-            %% Got headers, skip and fetch actual data
-            %% Ensure StartHeaders is set even when stream_start is consumed here.
+    case stream_owner_next_message(RequestId, ZlibCtx) of
+        {start, _Hs, NewZlib} ->
             Norm = normalize_headers(_Hs),
             lists:foreach(fun(W) -> W ! {stream_start_headers, Norm} end, StartWaiters),
-            handle_fetch_next_after_start(From, RequestId, Norm, []);
-        Msg ->
-            %% Got chunk/finished/error - deliver it
-            deliver_message(From, Msg, RequestId, StartHeaders, StartWaiters)
+            handle_fetch_next_after_start(From, RequestId, Norm, [], NewZlib);
+        {Msg, NewZlib} ->
+            deliver_message(From, Msg, RequestId, StartHeaders, StartWaiters, NewZlib)
     end;
-handle_fetch_next(From, RequestId, [Item | Rest], StartHeaders, StartWaiters) ->
-    %% Buffer has items - deliver first one
-    deliver_message(From, Item, RequestId, Rest, StartHeaders, StartWaiters).
+handle_fetch_next(From, RequestId, [Item | Rest], StartHeaders, StartWaiters, ZlibCtx) ->
+    deliver_message(From, Item, RequestId, Rest, StartHeaders, StartWaiters, ZlibCtx).
 
 %% Handle fetch_next after receiving stream_start (headers)
-handle_fetch_next_after_start(From, RequestId, StartHeaders, StartWaiters) ->
-    case stream_owner_next_message(RequestId) of
-        {chunk, Bin} ->
+handle_fetch_next_after_start(From, RequestId, StartHeaders, StartWaiters, ZlibCtx) ->
+    case stream_owner_next_message(RequestId, ZlibCtx) of
+        {{chunk, Bin}, NewZlib} ->
             From ! {stream_chunk, Bin},
-            stream_owner_wait(RequestId, [], StartHeaders, StartWaiters);
-        {finished, Headers} ->
+            stream_owner_wait(RequestId, [], StartHeaders, StartWaiters, NewZlib);
+        {{finished, Headers}, _NewZlib} ->
             From ! {stream_end, Headers},
             ok;
-        {error, Reason} ->
+        {{error, Reason}, _NewZlib} ->
             From ! {stream_error, Reason},
             ok
     end.
 
-%% Deliver a message to the client (from live stream)
-deliver_message(From, {chunk, Bin}, RequestId, StartHeaders, StartWaiters) ->
+%% Deliver a message to the client (from live stream, with ZlibCtx)
+deliver_message(From, {chunk, Bin}, RequestId, StartHeaders, StartWaiters, ZlibCtx) ->
     From ! {stream_chunk, Bin},
-    stream_owner_wait(RequestId, [], StartHeaders, StartWaiters);
-deliver_message(From, {finished, Headers}, _RequestId, _StartHeaders, _StartWaiters) ->
+    stream_owner_wait(RequestId, [], StartHeaders, StartWaiters, ZlibCtx);
+deliver_message(From, {finished, Headers}, _RequestId, _StartHeaders, _StartWaiters, _ZlibCtx) ->
     From ! {stream_end, Headers},
     ok;
-deliver_message(From, {error, Reason}, _RequestId, _StartHeaders, _StartWaiters) ->
+deliver_message(From, {error, Reason}, _RequestId, _StartHeaders, _StartWaiters, _ZlibCtx) ->
     From ! {stream_error, Reason},
     ok.
 
-%% Deliver a message to the client (from buffer)
-deliver_message(From, {chunk, Bin}, RequestId, Rest, StartHeaders, StartWaiters) ->
+%% Deliver a message to the client (from buffer, with ZlibCtx)
+deliver_message(From, {chunk, Bin}, RequestId, Rest, StartHeaders, StartWaiters, ZlibCtx) ->
     From ! {stream_chunk, Bin},
-    stream_owner_wait(RequestId, Rest, StartHeaders, StartWaiters);
+    stream_owner_wait(RequestId, Rest, StartHeaders, StartWaiters, ZlibCtx);
 deliver_message(From,
                 {finished, Headers},
                 _RequestId,
                 _Rest,
                 _StartHeaders,
-                _StartWaiters) ->
+                _StartWaiters,
+                _ZlibCtx) ->
     From ! {stream_end, Headers},
     ok;
-deliver_message(From, {error, Reason}, _RequestId, _Rest, _StartHeaders, _StartWaiters) ->
+deliver_message(From, {error, Reason}, _RequestId, _Rest, _StartHeaders, _StartWaiters, _ZlibCtx) ->
     From ! {stream_error, Reason},
     ok.
 
@@ -250,22 +253,33 @@ normalize_headers_default(undefined) ->
 normalize_headers_default(Headers) ->
     Headers.
 
-%% Wait for the next HTTP message from httpc
-stream_owner_next_message(RequestId) ->
+%% Wait for the next HTTP message from httpc.
+%% Returns {start, Headers, NewZlibCtx} | {{chunk|finished|error, Data}, NewZlibCtx}
+stream_owner_next_message(RequestId, ZlibCtx) ->
     receive
         {http, {RequestId, stream_start, Headers}} ->
-            {start, Headers};
+            NewZlib = maybe_init_stream_zlib(Headers),
+            {start, Headers, NewZlib};
         {http, {RequestId, stream_start, Headers, _Pid}} ->
-            %% Some httpc versions include pid
-            {start, Headers};
+            NewZlib = maybe_init_stream_zlib(Headers),
+            {start, Headers, NewZlib};
         {http, {RequestId, stream, Bin}} ->
-            {chunk, Bin};
+            DecompBin = case ZlibCtx of
+                undefined -> Bin;
+                _ -> decompress_chunk(ZlibCtx, Bin)
+            end,
+            {{chunk, DecompBin}, ZlibCtx};
         {http, {RequestId, stream_end, Headers}} ->
-            {finished, Headers};
+            cleanup_zlib(ZlibCtx),
+            {{finished, normalize_headers(Headers)}, undefined};
         {http, {RequestId, {error, Reason}}} ->
-            {error, Reason};
+            cleanup_zlib(ZlibCtx),
+            {{error, Reason}, undefined};
+        {http, {RequestId, {{_HttpVersion, StatusCode, ReasonPhrase}, _Headers, Body}}} ->
+            cleanup_zlib(ZlibCtx),
+            {{error, format_complete_response_error(StatusCode, ReasonPhrase, Body)}, undefined};
         _Other ->
-            stream_owner_next_message(RequestId)
+            stream_owner_next_message(RequestId, ZlibCtx)
     end.
 
 %% Ensure an Erlang application is started
@@ -306,6 +320,105 @@ to_headers(Hs) when is_list(Hs) ->
     lists:map(fun({K, V}) -> {to_list(K), to_list(V)} end, Hs);
 to_headers(Other) ->
     Other.
+
+%% Inject Accept-Encoding: gzip, deflate unless the user already set one
+maybe_add_accept_encoding(Headers) ->
+    HasAcceptEncoding = lists:any(
+        fun({K, _V}) ->
+            string:lowercase(to_list(K)) =:= "accept-encoding"
+        end, Headers),
+    case HasAcceptEncoding of
+        true -> Headers;
+        false -> Headers ++ [{"Accept-Encoding", "gzip, deflate"}]
+    end.
+
+%% Get Content-Encoding header value (lowercase, trimmed)
+get_content_encoding(Headers) ->
+    Val = lists:foldl(
+        fun({K, V}, Acc) ->
+            case string:lowercase(to_list(K)) of
+                "content-encoding" -> string:trim(string:lowercase(to_list(V)));
+                _ -> Acc
+            end
+        end, "", Headers),
+    Val.
+
+%% Remove a header by name (case-insensitive)
+remove_header(Name, Headers) ->
+    NormName = string:lowercase(Name),
+    lists:filter(
+        fun({K, _V}) -> string:lowercase(to_list(K)) =/= NormName end,
+        Headers).
+
+%% Decompress a sync response body based on Content-Encoding.
+%% Returns {DecompressedBody, CleanedHeaders}.
+maybe_decompress_response(Body, Headers) ->
+    Encoding = get_content_encoding(Headers),
+    case Encoding of
+        "gzip" ->
+            try_decompress(fun() -> zlib:gunzip(iolist_to_binary(Body)) end,
+                           Body, Headers);
+        "deflate" ->
+            try_decompress(fun() -> zlib:uncompress(iolist_to_binary(Body)) end,
+                           Body, Headers);
+        "identity" ->
+            {Body, Headers};
+        "" ->
+            {Body, Headers};
+        Other ->
+            io:format("WARNING: unrecognized Content-Encoding, passing through raw bytes: ~s~n",
+                      [to_binary(Other)]),
+            {Body, Headers}
+    end.
+
+try_decompress(DecompressFn, OrigBody, Headers) ->
+    try
+        Decompressed = DecompressFn(),
+        {Decompressed, remove_header("content-encoding", Headers)}
+    catch
+        _:_ ->
+            io:format("WARNING: decompression failed, passing through raw bytes~n"),
+            {OrigBody, Headers}
+    end.
+
+%% Detect stream encoding from headers.
+%% Returns {gzip, 31} | {deflate, 15} | none
+detect_stream_encoding(Headers) ->
+    Encoding = get_content_encoding(Headers),
+    case Encoding of
+        "gzip" -> {gzip, 31};
+        "deflate" -> {deflate, 15};
+        "" -> none;
+        "identity" -> none;
+        Other ->
+            io:format("WARNING: unrecognized Content-Encoding for stream, passing through raw bytes: ~s~n",
+                      [to_binary(Other)]),
+            none
+    end.
+
+%% Initialize a zlib inflate context for streaming decompression
+init_zlib_context(WindowBits) ->
+    Z = zlib:open(),
+    ok = zlib:inflateInit(Z, WindowBits),
+    Z.
+
+%% Initialize streaming zlib context from headers if Content-Encoding is gzip/deflate
+maybe_init_stream_zlib(Headers) ->
+    case detect_stream_encoding(Headers) of
+        {_Enc, WindowBits} -> init_zlib_context(WindowBits);
+        none -> undefined
+    end.
+
+%% Decompress a chunk using an existing zlib context
+decompress_chunk(ZlibCtx, Chunk) ->
+    iolist_to_binary(zlib:inflate(ZlibCtx, Chunk)).
+
+%% Clean up a zlib context
+cleanup_zlib(undefined) -> ok;
+cleanup_zlib(ZlibCtx) ->
+    try zlib:inflateEnd(ZlibCtx) catch _:_ -> ok end,
+    try zlib:close(ZlibCtx) catch _:_ -> ok end,
+    ok.
 
 %% Extract Content-Type header value (case-insensitive) and strip it from headers.
 %%
@@ -393,7 +506,7 @@ request_stream_messages(Method, Url, Headers, Body, _ReceiverPid, TimeoutMs) ->
     ensure_ref_mapping_table(),
 
     NUrl = to_list(Url),
-    NHeaders = to_headers(Headers),
+    NHeaders = maybe_add_accept_encoding(to_headers(Headers)),
     Req = build_req(NUrl, NHeaders, Body),
 
     HttpOpts = [{timeout, TimeoutMs}, {connect_timeout, 15000}, {autoredirect, true}],
@@ -516,16 +629,29 @@ cancel_stream_by_string(StringId) ->
 receive_stream_message(TimeoutMs) ->
     receive
         {http, {RequestId, stream_start, Headers}} ->
+            StringId = get_or_create_string_id(RequestId),
+            maybe_store_stream_zlib(StringId, Headers),
             {stream_start, RequestId, normalize_headers(Headers)};
         {http, {RequestId, stream_start, Headers, _Pid}} ->
-            %% Some httpc versions include pid
+            StringId = get_or_create_string_id(RequestId),
+            maybe_store_stream_zlib(StringId, Headers),
             {stream_start, RequestId, normalize_headers(Headers)};
         {http, {RequestId, stream, Data}} ->
-            {chunk, RequestId, Data};
+            StringId = get_or_create_string_id(RequestId),
+            DecompData = maybe_decompress_stream_chunk(StringId, Data),
+            {chunk, RequestId, DecompData};
         {http, {RequestId, stream_end, Headers}} ->
+            StringId = get_or_create_string_id(RequestId),
+            cleanup_stream_zlib(StringId),
             {stream_end, RequestId, normalize_headers(Headers)};
         {http, {RequestId, {error, Reason}}} ->
-            {stream_error, RequestId, format_error(Reason)}
+            StringId = get_or_create_string_id(RequestId),
+            cleanup_stream_zlib(StringId),
+            {stream_error, RequestId, format_error(Reason)};
+        {http, {RequestId, {{_HttpVersion, StatusCode, ReasonPhrase}, _Headers, Body}}} ->
+            StringId = get_or_create_string_id(RequestId),
+            cleanup_stream_zlib(StringId),
+            {stream_error, RequestId, format_complete_response_error(StatusCode, ReasonPhrase, Body)}
     after TimeoutMs ->
         timeout
     end.
@@ -577,23 +703,31 @@ decode_stream_message_for_selector({http, InnerMessage}) ->
     case InnerMessage of
         {HttpcRef, stream_start, Headers} ->
             StringId = get_or_create_string_id(HttpcRef),
+            maybe_store_stream_zlib(StringId, Headers),
             {stream_start, StringId, normalize_headers(Headers)};
         {HttpcRef, stream_start, Headers, _Pid} ->
             StringId = get_or_create_string_id(HttpcRef),
+            maybe_store_stream_zlib(StringId, Headers),
             {stream_start, StringId, normalize_headers(Headers)};
         {HttpcRef, stream, Data} ->
             StringId = get_or_create_string_id(HttpcRef),
-            {chunk, StringId, Data};
+            DecompData = maybe_decompress_stream_chunk(StringId, Data),
+            {chunk, StringId, DecompData};
         {HttpcRef, stream_end, Headers} ->
             StringId = get_or_create_string_id(HttpcRef),
-            %% Stream ended - clean up ref mapping
+            cleanup_stream_zlib(StringId),
             remove_ref_mapping(StringId),
             {stream_end, StringId, normalize_headers(Headers)};
         {HttpcRef, {error, Reason}} ->
             StringId = get_or_create_string_id(HttpcRef),
-            %% Stream errored - clean up ref mapping
+            cleanup_stream_zlib(StringId),
             remove_ref_mapping(StringId),
             {stream_error, StringId, format_error(Reason)};
+        {HttpcRef, {{_HttpVersion, StatusCode, ReasonPhrase}, _Headers, Body}} ->
+            StringId = get_or_create_string_id(HttpcRef),
+            cleanup_stream_zlib(StringId),
+            remove_ref_mapping(StringId),
+            {stream_error, StringId, format_complete_response_error(StatusCode, ReasonPhrase, Body)};
         _ ->
             error(badarg)
     end.
@@ -701,7 +835,7 @@ request_sync(Method, Url, Headers, Body, TimeoutMs) ->
     ok = configure_httpc(),
 
     NUrl = to_list(Url),
-    NHeaders = to_headers(Headers),
+    NHeaders = maybe_add_accept_encoding(to_headers(Headers)),
     Req = build_req(NUrl, NHeaders, Body),
 
     %% Use synchronous mode WITHOUT streaming - this is what send() should use
@@ -710,13 +844,28 @@ request_sync(Method, Url, Headers, Body, TimeoutMs) ->
 
     case httpc:request(Method, Req, HttpOpts, Opts) of
         {ok, {{_Version, StatusCode, _ReasonPhrase}, ResponseHeaders, ResponseBody}} ->
-            {ok, {StatusCode, normalize_headers(ResponseHeaders), ResponseBody}};
+            {DecompressedBody, CleanHeaders} =
+                maybe_decompress_response(ResponseBody, ResponseHeaders),
+            {ok, {StatusCode, normalize_headers(CleanHeaders), DecompressedBody}};
         {error, Reason} ->
             {error, format_error(Reason)}
     end.
 
 format_error(Reason) ->
     iolist_to_binary(io_lib:format("~p", [Reason])).
+
+%% Format error for a complete (non-streaming) HTTP response from httpc.
+%% httpc sends this instead of stream_start/stream/stream_end when the upstream
+%% returns a non-streaming response (typically 4xx/5xx errors).
+format_complete_response_error(StatusCode, ReasonPhrase, Body) ->
+    iolist_to_binary([
+        <<"HTTP ">>,
+        integer_to_binary(StatusCode),
+        <<" ">>,
+        to_binary(ReasonPhrase),
+        <<": ">>,
+        to_binary(Body)
+    ]).
 
 %% Format exit reason from owner process death
 %%
@@ -963,6 +1112,38 @@ lookup_string_by_ref(HttpcRef) ->
             {some, StringId};
         [] ->
             none
+    end.
+
+%% Store a zlib context in ETS for message-based streaming decompression
+maybe_store_stream_zlib(StringId, Headers) ->
+    case detect_stream_encoding(Headers) of
+        {_Enc, WindowBits} ->
+            Z = init_zlib_context(WindowBits),
+            ensure_ref_mapping_table(),
+            ets:insert(?REF_MAPPING_TABLE, {{zlib, StringId}, Z}),
+            ok;
+        none ->
+            ok
+    end.
+
+%% Decompress a chunk using ETS-stored zlib context
+maybe_decompress_stream_chunk(StringId, Data) ->
+    case ets:lookup(?REF_MAPPING_TABLE, {zlib, StringId}) of
+        [{{zlib, StringId}, Z}] ->
+            decompress_chunk(Z, Data);
+        [] ->
+            Data
+    end.
+
+%% Clean up ETS-stored zlib context
+cleanup_stream_zlib(StringId) ->
+    case ets:lookup(?REF_MAPPING_TABLE, {zlib, StringId}) of
+        [{{zlib, StringId}, Z}] ->
+            cleanup_zlib(Z),
+            ets:delete(?REF_MAPPING_TABLE, {zlib, StringId}),
+            ok;
+        [] ->
+            ok
     end.
 
 %% Remove both mappings (cleanup after stream ends)

--- a/modules/http_client/test/compression_test.gleam
+++ b/modules/http_client/test/compression_test.gleam
@@ -1,0 +1,508 @@
+//// Compression tests - full permutation matrix
+////
+//// Tests transparent gzip/deflate decompression across all three HTTP client
+//// execution modes (send, start_stream, stream_yielder), header injection,
+//// edge cases, and zlib lifecycle cleanup.
+
+import dream_http_client/client.{Header}
+import dream_http_client_test
+import gleam/bit_array
+import gleam/bytes_tree
+import gleam/erlang/process
+import gleam/http
+import gleam/io
+import gleam/list
+import gleam/string
+import gleam/yielder
+import gleeunit/should
+
+fn mock_request(path: String) -> client.ClientRequest {
+  client.new()
+  |> client.method(http.Get)
+  |> client.scheme(http.Http)
+  |> client.host("localhost")
+  |> client.port(dream_http_client_test.get_test_port())
+  |> client.path(path)
+}
+
+// ============================================================================
+// A. Sync tests (send()) -- one per encoding type
+// ============================================================================
+
+/// 1. send() decompresses gzip response transparently
+pub fn send_decompresses_gzip_response_test() {
+  let req = mock_request("/gzip")
+  let assert Ok(resp) = client.send(req)
+  resp.status |> should.equal(200)
+  resp.body |> should.equal("Hello, World!")
+}
+
+/// 2. send() decompresses deflate response transparently
+pub fn send_decompresses_deflate_response_test() {
+  let req = mock_request("/deflate")
+  let assert Ok(resp) = client.send(req)
+  resp.status |> should.equal(200)
+  resp.body |> should.equal("Hello, World!")
+}
+
+/// 3. send() passes through identity encoding (no-op)
+pub fn send_passes_through_identity_encoding_test() {
+  let req = mock_request("/identity")
+  let assert Ok(resp) = client.send(req)
+  resp.status |> should.equal(200)
+  resp.body |> should.equal("Hello, World!")
+}
+
+/// 4. send() passes through unknown encoding without crashing
+pub fn send_passes_through_unknown_encoding_test() {
+  let req = mock_request("/unknown-encoding")
+  let assert Ok(resp) = client.send(req)
+  resp.status |> should.equal(200)
+  { string.length(resp.body) > 0 } |> should.be_true()
+}
+
+/// 5. send() works normally without any Content-Encoding header
+pub fn send_works_without_content_encoding_test() {
+  let req = mock_request("/text")
+  let assert Ok(resp) = client.send(req)
+  resp.status |> should.equal(200)
+  { string.length(resp.body) > 0 } |> should.be_true()
+}
+
+/// 6. send() preserves user-set Accept-Encoding header
+pub fn send_preserves_user_accept_encoding_test() {
+  let req =
+    mock_request("/echo-accept-encoding")
+    |> client.headers([Header("Accept-Encoding", "zstd")])
+  let assert Ok(resp) = client.send(req)
+  resp.status |> should.equal(200)
+  resp.body |> should.equal("zstd")
+}
+
+/// 7. send() handles corrupted gzip data gracefully (error, not crash)
+pub fn send_errors_on_corrupted_gzip_test() {
+  let req = mock_request("/corrupted-gzip")
+  case client.send(req) {
+    Ok(resp) -> {
+      // If httpc returns the raw data, that's also acceptable -
+      // the important thing is it doesn't crash the process
+      { resp.status == 200 } |> should.be_true()
+    }
+    Error(_) -> {
+      // Error is fine -- decompression failure surfaced
+      Nil
+    }
+  }
+}
+
+// ============================================================================
+// B. Callback-based streaming tests (start_stream())
+// ============================================================================
+
+/// 8. start_stream decompresses gzip-compressed chunks
+pub fn start_stream_decompresses_gzip_chunks_test() {
+  let chunks_subject = process.new_subject()
+  let ended_subject = process.new_subject()
+
+  let request =
+    mock_request("/stream/gzip")
+    |> client.on_stream_chunk(fn(data) { process.send(chunks_subject, data) })
+    |> client.on_stream_end(fn(_headers) { process.send(ended_subject, True) })
+
+  let assert Ok(_handle) = client.start_stream(request)
+
+  case process.receive(ended_subject, 10_000) {
+    Ok(True) -> Nil
+    Ok(False) -> should.fail()
+    Error(Nil) -> {
+      io.println("start_stream gzip: on_stream_end was never called")
+      should.fail()
+    }
+  }
+
+  let chunks = collect_chunks(chunks_subject, [])
+  { chunks != [] } |> should.be_true()
+
+  let combined = combine_chunks(chunks)
+  string.contains(combined, "Chunk 1") |> should.be_true()
+  string.contains(combined, "Chunk 5") |> should.be_true()
+}
+
+/// 9. start_stream decompresses deflate-compressed chunks
+pub fn start_stream_decompresses_deflate_chunks_test() {
+  let chunks_subject = process.new_subject()
+  let ended_subject = process.new_subject()
+
+  let request =
+    mock_request("/stream/deflate")
+    |> client.on_stream_chunk(fn(data) { process.send(chunks_subject, data) })
+    |> client.on_stream_end(fn(_headers) { process.send(ended_subject, True) })
+
+  let assert Ok(_handle) = client.start_stream(request)
+
+  case process.receive(ended_subject, 10_000) {
+    Ok(True) -> Nil
+    Ok(False) -> should.fail()
+    Error(Nil) -> {
+      io.println("start_stream deflate: on_stream_end was never called")
+      should.fail()
+    }
+  }
+
+  let chunks = collect_chunks(chunks_subject, [])
+  { chunks != [] } |> should.be_true()
+
+  let combined = combine_chunks(chunks)
+  string.contains(combined, "Chunk 1") |> should.be_true()
+  string.contains(combined, "Chunk 5") |> should.be_true()
+}
+
+/// 10. start_stream passes through unknown encoding without crashing
+pub fn start_stream_passes_through_unknown_encoding_chunks_test() {
+  let chunks_subject = process.new_subject()
+  let ended_subject = process.new_subject()
+  let error_subject = process.new_subject()
+
+  let request =
+    mock_request("/stream/unknown-encoding")
+    |> client.on_stream_chunk(fn(data) { process.send(chunks_subject, data) })
+    |> client.on_stream_end(fn(_headers) { process.send(ended_subject, True) })
+    |> client.on_stream_error(fn(reason) { process.send(error_subject, reason) })
+
+  let assert Ok(_handle) = client.start_stream(request)
+
+  case process.receive(ended_subject, 10_000) {
+    Ok(True) -> {
+      let chunks = collect_chunks(chunks_subject, [])
+      { chunks != [] } |> should.be_true()
+    }
+    Ok(False) -> should.fail()
+    Error(Nil) -> {
+      case process.receive(error_subject, 1000) {
+        Ok(_reason) -> Nil
+        Error(Nil) -> {
+          io.println("start_stream unknown-encoding: neither end nor error")
+          should.fail()
+        }
+      }
+    }
+  }
+}
+
+/// 11. start_stream works without encoding (regression guard)
+pub fn start_stream_works_without_encoding_test() {
+  let chunks_subject = process.new_subject()
+  let ended_subject = process.new_subject()
+
+  let request =
+    mock_request("/stream/fast")
+    |> client.on_stream_chunk(fn(data) { process.send(chunks_subject, data) })
+    |> client.on_stream_end(fn(_headers) { process.send(ended_subject, True) })
+
+  let assert Ok(_handle) = client.start_stream(request)
+
+  case process.receive(ended_subject, 5000) {
+    Ok(True) -> Nil
+    Ok(False) -> should.fail()
+    Error(Nil) -> {
+      io.println("on_stream_end was never called")
+      should.fail()
+    }
+  }
+
+  let chunks = collect_chunks(chunks_subject, [])
+  { chunks != [] } |> should.be_true()
+}
+
+// ============================================================================
+// C. Pull-based streaming tests (stream_yielder())
+// ============================================================================
+
+/// 12. stream_yielder decompresses gzip-compressed chunks
+pub fn stream_yielder_decompresses_gzip_chunks_test() {
+  let req = mock_request("/stream/gzip")
+  let results = client.stream_yielder(req) |> yielder.to_list
+
+  { results != [] } |> should.be_true()
+
+  let ok_chunks =
+    list.filter_map(results, fn(r) {
+      case r {
+        Ok(bt) -> Ok(bytes_tree.to_bit_array(bt))
+        Error(_) -> Error(Nil)
+      }
+    })
+
+  { ok_chunks != [] } |> should.be_true()
+
+  let combined = combine_chunks(ok_chunks)
+  string.contains(combined, "Chunk 1") |> should.be_true()
+  string.contains(combined, "Chunk 5") |> should.be_true()
+}
+
+/// 13. stream_yielder decompresses deflate-compressed chunks
+pub fn stream_yielder_decompresses_deflate_chunks_test() {
+  let req = mock_request("/stream/deflate")
+  let results = client.stream_yielder(req) |> yielder.to_list
+
+  { results != [] } |> should.be_true()
+
+  let ok_chunks =
+    list.filter_map(results, fn(r) {
+      case r {
+        Ok(bt) -> Ok(bytes_tree.to_bit_array(bt))
+        Error(_) -> Error(Nil)
+      }
+    })
+
+  { ok_chunks != [] } |> should.be_true()
+
+  let combined = combine_chunks(ok_chunks)
+  string.contains(combined, "Chunk 1") |> should.be_true()
+  string.contains(combined, "Chunk 5") |> should.be_true()
+}
+
+/// 14. stream_yielder passes through unknown encoding without crashing
+pub fn stream_yielder_passes_through_unknown_encoding_chunks_test() {
+  let req = mock_request("/stream/unknown-encoding")
+  let results = client.stream_yielder(req) |> yielder.to_list
+
+  { results != [] } |> should.be_true()
+
+  let all_ok =
+    list.all(results, fn(r) {
+      case r {
+        Ok(_) -> True
+        Error(_) -> False
+      }
+    })
+  all_ok |> should.be_true()
+}
+
+/// 15. stream_yielder works without encoding (regression guard)
+pub fn stream_yielder_works_without_encoding_test() {
+  let req = mock_request("/stream/fast")
+  let results = client.stream_yielder(req) |> yielder.to_list
+
+  { results != [] } |> should.be_true()
+
+  let all_ok =
+    list.all(results, fn(r) {
+      case r {
+        Ok(_) -> True
+        Error(reason) -> {
+          io.println("Unexpected error: " <> reason)
+          False
+        }
+      }
+    })
+  all_ok |> should.be_true()
+}
+
+// ============================================================================
+// D. Header injection tests
+// ============================================================================
+
+/// 16. send() auto-injects Accept-Encoding: gzip, deflate
+pub fn send_auto_injects_accept_encoding_test() {
+  let req = mock_request("/echo-accept-encoding")
+  let assert Ok(resp) = client.send(req)
+  resp.status |> should.equal(200)
+  resp.body |> should.equal("gzip, deflate")
+}
+
+/// 17. start_stream auto-injects Accept-Encoding: gzip, deflate
+pub fn start_stream_auto_injects_accept_encoding_test() {
+  let chunks_subject = process.new_subject()
+  let ended_subject = process.new_subject()
+
+  let request =
+    mock_request("/echo-accept-encoding")
+    |> client.on_stream_chunk(fn(data) { process.send(chunks_subject, data) })
+    |> client.on_stream_end(fn(_headers) { process.send(ended_subject, True) })
+    |> client.on_stream_error(fn(reason) {
+      process.send(ended_subject, False)
+      io.println("Error in header injection test: " <> reason)
+    })
+
+  let assert Ok(_handle) = client.start_stream(request)
+
+  case process.receive(ended_subject, 5000) {
+    Ok(_) -> Nil
+    Error(Nil) -> {
+      io.println("start_stream header injection: timed out")
+      should.fail()
+    }
+  }
+
+  let chunks = collect_chunks(chunks_subject, [])
+  let combined = combine_chunks(chunks)
+  string.contains(combined, "gzip, deflate") |> should.be_true()
+}
+
+/// 18. stream_yielder auto-injects Accept-Encoding: gzip, deflate
+pub fn stream_yielder_auto_injects_accept_encoding_test() {
+  let req = mock_request("/echo-accept-encoding")
+  let results = client.stream_yielder(req) |> yielder.to_list
+
+  let ok_chunks =
+    list.filter_map(results, fn(r) {
+      case r {
+        Ok(bt) -> Ok(bytes_tree.to_bit_array(bt))
+        Error(_) -> Error(Nil)
+      }
+    })
+
+  let combined = combine_chunks(ok_chunks)
+  string.contains(combined, "gzip, deflate") |> should.be_true()
+}
+
+/// 19. send() preserves custom Accept-Encoding
+pub fn send_preserves_custom_accept_encoding_test() {
+  let req =
+    mock_request("/echo-accept-encoding")
+    |> client.headers([Header("Accept-Encoding", "zstd")])
+  let assert Ok(resp) = client.send(req)
+  resp.body |> should.equal("zstd")
+}
+
+/// 20. start_stream preserves custom Accept-Encoding
+pub fn start_stream_preserves_custom_accept_encoding_test() {
+  let chunks_subject = process.new_subject()
+  let ended_subject = process.new_subject()
+
+  let request =
+    mock_request("/echo-accept-encoding")
+    |> client.headers([Header("Accept-Encoding", "zstd")])
+    |> client.on_stream_chunk(fn(data) { process.send(chunks_subject, data) })
+    |> client.on_stream_end(fn(_headers) { process.send(ended_subject, True) })
+    |> client.on_stream_error(fn(reason) {
+      process.send(ended_subject, False)
+      io.println("Error in preserve test: " <> reason)
+    })
+
+  let assert Ok(_handle) = client.start_stream(request)
+
+  case process.receive(ended_subject, 5000) {
+    Ok(_) -> Nil
+    Error(Nil) -> {
+      io.println("start_stream preserve: timed out")
+      should.fail()
+    }
+  }
+
+  let chunks = collect_chunks(chunks_subject, [])
+  let combined = combine_chunks(chunks)
+  combined |> should.equal("zstd")
+}
+
+/// 21. stream_yielder preserves custom Accept-Encoding
+pub fn stream_yielder_preserves_custom_accept_encoding_test() {
+  let req =
+    mock_request("/echo-accept-encoding")
+    |> client.headers([Header("Accept-Encoding", "zstd")])
+  let results = client.stream_yielder(req) |> yielder.to_list
+
+  let ok_chunks =
+    list.filter_map(results, fn(r) {
+      case r {
+        Ok(bt) -> Ok(bytes_tree.to_bit_array(bt))
+        Error(_) -> Error(Nil)
+      }
+    })
+
+  let combined = combine_chunks(ok_chunks)
+  combined |> should.equal("zstd")
+}
+
+// ============================================================================
+// E. Zlib lifecycle tests (verify cleanup, no resource leaks)
+// ============================================================================
+
+/// 22. start_stream gzip: zlib cleaned up on normal stream end
+pub fn start_stream_gzip_cleans_up_zlib_on_stream_end_test() {
+  let ended_subject = process.new_subject()
+
+  let request =
+    mock_request("/stream/gzip")
+    |> client.on_stream_chunk(fn(_data) { Nil })
+    |> client.on_stream_end(fn(_headers) { process.send(ended_subject, True) })
+
+  let assert Ok(handle) = client.start_stream(request)
+
+  case process.receive(ended_subject, 10_000) {
+    Ok(True) -> Nil
+    Ok(False) -> should.fail()
+    Error(Nil) -> {
+      io.println("Zlib cleanup test: stream_end never called")
+      should.fail()
+    }
+  }
+
+  client.await_stream(handle)
+  client.is_stream_active(handle) |> should.be_false()
+}
+
+/// 23. stream_yielder gzip: zlib cleaned up on normal stream end
+pub fn stream_yielder_gzip_cleans_up_zlib_on_stream_end_test() {
+  let req = mock_request("/stream/gzip")
+  let results = client.stream_yielder(req) |> yielder.to_list
+
+  { results != [] } |> should.be_true()
+
+  let all_ok =
+    list.all(results, fn(r) {
+      case r {
+        Ok(_) -> True
+        Error(_) -> False
+      }
+    })
+  all_ok |> should.be_true()
+}
+
+/// 24. start_stream gzip: zlib cleaned up even on error
+pub fn start_stream_gzip_cleans_up_zlib_on_error_test() {
+  let error_subject = process.new_subject()
+
+  let request =
+    mock_request("/status/500")
+    |> client.on_stream_chunk(fn(_data) { Nil })
+    |> client.on_stream_end(fn(_headers) { Nil })
+    |> client.on_stream_error(fn(reason) { process.send(error_subject, reason) })
+
+  let assert Ok(handle) = client.start_stream(request)
+
+  case process.receive(error_subject, 5000) {
+    Ok(_reason) -> Nil
+    Error(Nil) -> {
+      io.println("Zlib error cleanup test: error never called")
+      should.fail()
+    }
+  }
+
+  client.await_stream(handle)
+  client.is_stream_active(handle) |> should.be_false()
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn collect_chunks(
+  subject: process.Subject(BitArray),
+  acc: List(BitArray),
+) -> List(BitArray) {
+  case process.receive(subject, 100) {
+    Ok(item) -> collect_chunks(subject, [item, ..acc])
+    Error(Nil) -> list.reverse(acc)
+  }
+}
+
+fn combine_chunks(chunks: List(BitArray)) -> String {
+  let combined =
+    list.fold(chunks, <<>>, fn(acc, chunk) { bit_array.append(acc, chunk) })
+  case bit_array.to_string(combined) {
+    Ok(s) -> s
+    Error(Nil) -> ""
+  }
+}

--- a/modules/http_client/test/stream_non_streaming_response_test.gleam
+++ b/modules/http_client/test/stream_non_streaming_response_test.gleam
@@ -1,0 +1,259 @@
+//// Regression tests for non-streaming upstream responses during streaming
+////
+//// When a streaming HTTP request is made via start_stream/stream_yielder and
+//// the upstream returns a non-streaming response (e.g. HTTP 401/500 with a
+//// JSON body), Erlang's httpc sends a complete response message instead of
+//// the expected stream_start/stream/stream_end sequence.
+////
+//// These tests verify that complete response messages are handled gracefully
+//// and surfaced through the existing error paths rather than crashing the
+//// stream process or silently hanging.
+
+import dream_http_client/client
+import dream_http_client_test
+import gleam/erlang/process
+import gleam/http
+import gleam/io
+import gleam/list
+import gleam/string
+import gleam/yielder
+import gleeunit/should
+
+fn mock_request(path: String) -> client.ClientRequest {
+  client.new()
+  |> client.method(http.Get)
+  |> client.scheme(http.Http)
+  |> client.host("localhost")
+  |> client.port(dream_http_client_test.get_test_port())
+  |> client.path(path)
+}
+
+// ============================================================================
+// start_stream callback-based path (exercises decode_stream_message_for_selector)
+// ============================================================================
+
+/// Streaming to a 401 endpoint must fire on_stream_error, not crash
+pub fn start_stream_calls_on_error_for_401_non_streaming_response_test() {
+  let error_subject = process.new_subject()
+
+  let request =
+    mock_request("/status/401")
+    |> client.on_stream_error(fn(reason) { process.send(error_subject, reason) })
+
+  let assert Ok(_handle) = client.start_stream(request)
+
+  case process.receive(error_subject, 3000) {
+    Ok(reason) -> {
+      string.contains(reason, "401") |> should.be_true()
+    }
+    Error(Nil) -> {
+      io.println("on_stream_error was never called (process likely crashed)")
+      should.fail()
+    }
+  }
+}
+
+/// Streaming to a 500 endpoint must fire on_stream_error, not crash
+pub fn start_stream_calls_on_error_for_500_non_streaming_response_test() {
+  let error_subject = process.new_subject()
+
+  let request =
+    mock_request("/status/500")
+    |> client.on_stream_error(fn(reason) { process.send(error_subject, reason) })
+
+  let assert Ok(_handle) = client.start_stream(request)
+
+  case process.receive(error_subject, 3000) {
+    Ok(reason) -> {
+      string.contains(reason, "500") |> should.be_true()
+    }
+    Error(Nil) -> {
+      io.println("on_stream_error was never called (process likely crashed)")
+      should.fail()
+    }
+  }
+}
+
+/// Error reason must contain the HTTP status code
+pub fn start_stream_error_contains_status_code_test() {
+  let error_subject = process.new_subject()
+
+  let request =
+    mock_request("/status/403")
+    |> client.on_stream_error(fn(reason) { process.send(error_subject, reason) })
+
+  let assert Ok(_handle) = client.start_stream(request)
+
+  case process.receive(error_subject, 3000) {
+    Ok(reason) -> {
+      string.contains(reason, "403") |> should.be_true()
+      string.contains(reason, "HTTP") |> should.be_true()
+    }
+    Error(Nil) -> {
+      io.println("on_stream_error was never called")
+      should.fail()
+    }
+  }
+}
+
+/// Error reason must contain the response body from upstream
+pub fn start_stream_error_contains_response_body_test() {
+  let error_subject = process.new_subject()
+
+  let request =
+    mock_request("/status/429")
+    |> client.on_stream_error(fn(reason) { process.send(error_subject, reason) })
+
+  let assert Ok(_handle) = client.start_stream(request)
+
+  case process.receive(error_subject, 3000) {
+    Ok(reason) -> {
+      string.contains(reason, "429") |> should.be_true()
+      { string.length(reason) > 10 } |> should.be_true()
+    }
+    Error(Nil) -> {
+      io.println("on_stream_error was never called")
+      should.fail()
+    }
+  }
+}
+
+/// Stream process must terminate cleanly, not crash, on non-streaming response
+pub fn start_stream_does_not_crash_process_on_non_streaming_response_test() {
+  let error_subject = process.new_subject()
+
+  let request =
+    mock_request("/status/401")
+    |> client.on_stream_error(fn(reason) { process.send(error_subject, reason) })
+
+  let assert Ok(handle) = client.start_stream(request)
+
+  // Wait for the error callback to fire
+  case process.receive(error_subject, 3000) {
+    Ok(_reason) -> Nil
+    Error(Nil) -> {
+      io.println("on_stream_error was never called")
+      should.fail()
+    }
+  }
+
+  // await_stream should return promptly without the caller timing out
+  client.await_stream(handle)
+  client.is_stream_active(handle) |> should.be_false()
+}
+
+// ============================================================================
+// stream_yielder pull-based path (exercises stream_owner_wait + stream_owner_next_message)
+// ============================================================================
+
+/// Yielder to a 401 endpoint must yield Error containing "401".
+/// Uses yielder.take(1) because the yielder retries on start errors (owner
+/// never gets set), which would make yielder.to_list loop infinitely.
+pub fn stream_yielder_returns_error_for_401_non_streaming_response_test() {
+  let req = mock_request("/status/401")
+  let results = client.stream_yielder(req) |> yielder.take(1) |> yielder.to_list
+
+  { results != [] } |> should.be_true()
+
+  let assert [first, ..] = results
+  case first {
+    Error(reason) -> string.contains(reason, "401") |> should.be_true()
+    Ok(_) -> {
+      io.println("Expected Error, got Ok")
+      should.fail()
+    }
+  }
+}
+
+/// Yielder to a 500 endpoint must yield Error containing "500"
+pub fn stream_yielder_returns_error_for_500_non_streaming_response_test() {
+  let req = mock_request("/status/500")
+  let results = client.stream_yielder(req) |> yielder.take(1) |> yielder.to_list
+
+  { results != [] } |> should.be_true()
+
+  let assert [first, ..] = results
+  case first {
+    Error(reason) -> string.contains(reason, "500") |> should.be_true()
+    Ok(_) -> {
+      io.println("Expected Error, got Ok")
+      should.fail()
+    }
+  }
+}
+
+/// Yielder error must contain the response body text
+pub fn stream_yielder_error_contains_response_body_test() {
+  let req = mock_request("/status/422")
+  let results = client.stream_yielder(req) |> yielder.take(1) |> yielder.to_list
+
+  { results != [] } |> should.be_true()
+
+  let assert [first, ..] = results
+  case first {
+    Error(reason) -> {
+      string.contains(reason, "422") |> should.be_true()
+      { string.length(reason) > 10 } |> should.be_true()
+    }
+    Ok(_) -> {
+      io.println("Expected Error, got Ok")
+      should.fail()
+    }
+  }
+}
+
+// ============================================================================
+// Normal streaming regression guards
+// ============================================================================
+
+/// Normal streaming via start_stream still works after the fix
+pub fn start_stream_normal_streaming_still_works_test() {
+  let chunks_subject = process.new_subject()
+  let ended_subject = process.new_subject()
+
+  let request =
+    mock_request("/stream/fast")
+    |> client.on_stream_chunk(fn(data) { process.send(chunks_subject, data) })
+    |> client.on_stream_end(fn(_headers) { process.send(ended_subject, True) })
+
+  let assert Ok(_handle) = client.start_stream(request)
+
+  case process.receive(ended_subject, 5000) {
+    Ok(True) -> Nil
+    Ok(False) -> should.fail()
+    Error(Nil) -> {
+      io.println("on_stream_end was never called")
+      should.fail()
+    }
+  }
+
+  let chunks = collect_from_subject(chunks_subject, [])
+  { chunks != [] } |> should.be_true()
+}
+
+/// Normal streaming via stream_yielder still works after the fix
+pub fn stream_yielder_normal_streaming_still_works_test() {
+  let req = mock_request("/stream/fast")
+  let results = client.stream_yielder(req) |> yielder.to_list
+
+  { results != [] } |> should.be_true()
+
+  let all_ok =
+    list.all(results, fn(result) {
+      case result {
+        Ok(_) -> True
+        Error(reason) -> {
+          io.println("Unexpected error in normal stream: " <> reason)
+          False
+        }
+      }
+    })
+  all_ok |> should.be_true()
+}
+
+fn collect_from_subject(subject: process.Subject(a), acc: List(a)) -> List(a) {
+  case process.receive(subject, 50) {
+    Ok(item) -> collect_from_subject(subject, [item, ..acc])
+    Error(Nil) -> list.reverse(acc)
+  }
+}

--- a/modules/mock_server/src/compression_ffi.erl
+++ b/modules/mock_server/src/compression_ffi.erl
@@ -1,0 +1,43 @@
+-module(compression_ffi).
+
+-export([gzip_compress/1, deflate_compress/1, gzip_compress_chunks/1,
+         deflate_compress_chunks/1]).
+
+gzip_compress(Data) when is_binary(Data) ->
+    zlib:gzip(Data).
+
+deflate_compress(Data) when is_binary(Data) ->
+    zlib:compress(Data).
+
+%% Compress each item and return a list of gzip-compressed chunks
+%% that together form one valid gzip stream.
+gzip_compress_chunks(DataList) when is_list(DataList) ->
+    Z = zlib:open(),
+    ok = zlib:deflateInit(Z, default, deflated, 31, 8, default),
+    Chunks = lists:map(
+        fun(Data) ->
+            Bin = ensure_binary(Data),
+            iolist_to_binary(zlib:deflate(Z, Bin, sync))
+        end, DataList),
+    Final = iolist_to_binary(zlib:deflate(Z, <<>>, finish)),
+    zlib:deflateEnd(Z),
+    zlib:close(Z),
+    Chunks ++ [Final].
+
+%% Compress each item and return a list of deflate-compressed chunks
+%% that together form one valid deflate/zlib stream.
+deflate_compress_chunks(DataList) when is_list(DataList) ->
+    Z = zlib:open(),
+    ok = zlib:deflateInit(Z),
+    Chunks = lists:map(
+        fun(Data) ->
+            Bin = ensure_binary(Data),
+            iolist_to_binary(zlib:deflate(Z, Bin, sync))
+        end, DataList),
+    Final = iolist_to_binary(zlib:deflate(Z, <<>>, finish)),
+    zlib:deflateEnd(Z),
+    zlib:close(Z),
+    Chunks ++ [Final].
+
+ensure_binary(Bin) when is_binary(Bin) -> Bin;
+ensure_binary(List) when is_list(List) -> list_to_binary(List).

--- a/modules/mock_server/src/dream_mock_server/compression.gleam
+++ b/modules/mock_server/src/dream_mock_server/compression.gleam
@@ -1,0 +1,13 @@
+//// Compression helpers for mock server endpoints (wraps zlib FFI)
+
+@external(erlang, "compression_ffi", "gzip_compress")
+pub fn gzip_compress(data: BitArray) -> BitArray
+
+@external(erlang, "compression_ffi", "deflate_compress")
+pub fn deflate_compress(data: BitArray) -> BitArray
+
+@external(erlang, "compression_ffi", "gzip_compress_chunks")
+pub fn gzip_compress_chunks(chunks: List(BitArray)) -> List(BitArray)
+
+@external(erlang, "compression_ffi", "deflate_compress_chunks")
+pub fn deflate_compress_chunks(chunks: List(BitArray)) -> List(BitArray)

--- a/modules/mock_server/src/dream_mock_server/controllers/api_controller.gleam
+++ b/modules/mock_server/src/dream_mock_server/controllers/api_controller.gleam
@@ -4,12 +4,15 @@
 //// All formatting is delegated to the view layer.
 
 import dream/context.{type EmptyContext}
+import dream/http/header.{Header}
 import dream/http/request.{type Request, get_int_param}
 import dream/http/response.{type Response, json_response, text_response}
 import dream/http/status
 import dream/router.{type EmptyServices}
+import dream_mock_server/compression
 import dream_mock_server/views/api_view
 import gleam/erlang/process
+import gleam/list
 import gleam/option
 import gleam/string
 
@@ -132,4 +135,113 @@ pub fn content_type(
 ) -> Response {
   let content_type = option.unwrap(request.content_type, "")
   text_response(status.ok, content_type)
+}
+
+/// GET /gzip - Returns "Hello, World!" gzip-compressed
+pub fn gzip(
+  _request: Request,
+  _context: EmptyContext,
+  _services: EmptyServices,
+) -> Response {
+  let body = compression.gzip_compress(<<"Hello, World!":utf8>>)
+  response.Response(
+    status: status.ok,
+    body: response.Bytes(body),
+    headers: [
+      Header("Content-Type", "text/plain"),
+      Header("Content-Encoding", "gzip"),
+    ],
+    cookies: [],
+    content_type: option.Some("text/plain"),
+  )
+}
+
+/// GET /deflate - Returns "Hello, World!" deflate-compressed
+pub fn deflate(
+  _request: Request,
+  _context: EmptyContext,
+  _services: EmptyServices,
+) -> Response {
+  let body = compression.deflate_compress(<<"Hello, World!":utf8>>)
+  response.Response(
+    status: status.ok,
+    body: response.Bytes(body),
+    headers: [
+      Header("Content-Type", "text/plain"),
+      Header("Content-Encoding", "deflate"),
+    ],
+    cookies: [],
+    content_type: option.Some("text/plain"),
+  )
+}
+
+/// GET /identity - Returns "Hello, World!" with Content-Encoding: identity
+pub fn identity(
+  _request: Request,
+  _context: EmptyContext,
+  _services: EmptyServices,
+) -> Response {
+  response.Response(
+    status: status.ok,
+    body: response.Text("Hello, World!"),
+    headers: [
+      Header("Content-Type", "text/plain; charset=utf-8"),
+      Header("Content-Encoding", "identity"),
+    ],
+    cookies: [],
+    content_type: option.Some("text/plain; charset=utf-8"),
+  )
+}
+
+/// GET /unknown-encoding - Returns raw bytes with Content-Encoding: br
+pub fn unknown_encoding(
+  _request: Request,
+  _context: EmptyContext,
+  _services: EmptyServices,
+) -> Response {
+  response.Response(
+    status: status.ok,
+    body: response.Text("raw-uncompressed-bytes"),
+    headers: [
+      Header("Content-Type", "text/plain; charset=utf-8"),
+      Header("Content-Encoding", "br"),
+    ],
+    cookies: [],
+    content_type: option.Some("text/plain; charset=utf-8"),
+  )
+}
+
+/// GET /corrupted-gzip - Returns garbage bytes with Content-Encoding: gzip
+pub fn corrupted_gzip(
+  _request: Request,
+  _context: EmptyContext,
+  _services: EmptyServices,
+) -> Response {
+  response.Response(
+    status: status.ok,
+    body: response.Bytes(<<"this is not valid gzip data at all":utf8>>),
+    headers: [
+      Header("Content-Type", "text/plain"),
+      Header("Content-Encoding", "gzip"),
+    ],
+    cookies: [],
+    content_type: option.Some("text/plain"),
+  )
+}
+
+/// GET /echo-accept-encoding - Echoes the request's Accept-Encoding header
+pub fn echo_accept_encoding(
+  request: Request,
+  _context: EmptyContext,
+  _services: EmptyServices,
+) -> Response {
+  let accept_encoding =
+    list.find(request.headers, fn(h) {
+      string.lowercase(h.name) == "accept-encoding"
+    })
+  let value = case accept_encoding {
+    Ok(found) -> found.value
+    Error(Nil) -> ""
+  }
+  text_response(status.ok, value)
 }

--- a/modules/mock_server/src/dream_mock_server/controllers/stream_controller.gleam
+++ b/modules/mock_server/src/dream_mock_server/controllers/stream_controller.gleam
@@ -4,16 +4,19 @@
 //// Each endpoint demonstrates different streaming behaviors and patterns.
 
 import dream/context.{type EmptyContext}
+import dream/http/header.{Header}
 import dream/http/request.{type Request}
 import dream/http/response.{type Response, stream_response, text_response}
 import dream/http/status
 import dream/router.{type EmptyServices}
+import dream_mock_server/compression
 import dream_mock_server/views/index_view
 import gleam/bit_array
 import gleam/erlang/process
 import gleam/int
 import gleam/json
 import gleam/list
+import gleam/option
 import gleam/yielder
 
 /// Index action - displays available endpoints (streaming and non-streaming)
@@ -185,6 +188,98 @@ pub fn stream_binary(
 
 fn create_binary_chunk(n: Int) -> BitArray {
   process.sleep(10)
-  // Create a binary chunk with repeating byte pattern
   <<n:8, n:8, n:8, n:8>>
+}
+
+/// Gzip-compressed streaming - 5 chunks, gzip-compressed as one stream
+pub fn stream_gzip(
+  _request: Request,
+  _context: EmptyContext,
+  _services: EmptyServices,
+) -> Response {
+  let plain_chunks =
+    yielder.range(1, 5)
+    |> yielder.map(fn(n) {
+      bit_array.from_string("Chunk " <> int.to_string(n) <> "\n")
+    })
+    |> yielder.to_list
+
+  let compressed_chunks = compression.gzip_compress_chunks(plain_chunks)
+
+  let stream =
+    yielder.from_list(compressed_chunks)
+    |> yielder.map(fn(chunk) {
+      process.sleep(50)
+      chunk
+    })
+
+  response.Response(
+    status: status.ok,
+    body: response.Stream(stream),
+    headers: [
+      Header("Content-Type", "text/plain"),
+      Header("Content-Encoding", "gzip"),
+    ],
+    cookies: [],
+    content_type: option.Some("text/plain"),
+  )
+}
+
+/// Deflate-compressed streaming - 5 chunks, deflate-compressed as one stream
+pub fn stream_deflate(
+  _request: Request,
+  _context: EmptyContext,
+  _services: EmptyServices,
+) -> Response {
+  let plain_chunks =
+    yielder.range(1, 5)
+    |> yielder.map(fn(n) {
+      bit_array.from_string("Chunk " <> int.to_string(n) <> "\n")
+    })
+    |> yielder.to_list
+
+  let compressed_chunks = compression.deflate_compress_chunks(plain_chunks)
+
+  let stream =
+    yielder.from_list(compressed_chunks)
+    |> yielder.map(fn(chunk) {
+      process.sleep(50)
+      chunk
+    })
+
+  response.Response(
+    status: status.ok,
+    body: response.Stream(stream),
+    headers: [
+      Header("Content-Type", "text/plain"),
+      Header("Content-Encoding", "deflate"),
+    ],
+    cookies: [],
+    content_type: option.Some("text/plain"),
+  )
+}
+
+/// Streaming with unknown Content-Encoding: br (raw passthrough)
+pub fn stream_unknown_encoding(
+  _request: Request,
+  _context: EmptyContext,
+  _services: EmptyServices,
+) -> Response {
+  let stream =
+    yielder.range(1, 5)
+    |> yielder.map(fn(n) {
+      process.sleep(50)
+      bit_array.from_string("Raw " <> int.to_string(n) <> "\n")
+    })
+
+  response.Response(
+    status: status.ok,
+    body: response.Stream(stream),
+    headers: [
+      Header("Content-Type", "text/plain"),
+      Header("Content-Encoding", "br"),
+    ],
+    cookies: [],
+    content_type: option.Some("text/plain"),
+  )
 }

--- a/modules/mock_server/src/dream_mock_server/router.gleam
+++ b/modules/mock_server/src/dream_mock_server/router.gleam
@@ -122,6 +122,43 @@ pub fn create_router() -> Router(EmptyContext, EmptyServices) {
     controller: api_controller.slow,
     middleware: [],
   )
+  // Compression endpoints
+  |> route(
+    method: Get,
+    path: "/gzip",
+    controller: api_controller.gzip,
+    middleware: [],
+  )
+  |> route(
+    method: Get,
+    path: "/deflate",
+    controller: api_controller.deflate,
+    middleware: [],
+  )
+  |> route(
+    method: Get,
+    path: "/identity",
+    controller: api_controller.identity,
+    middleware: [],
+  )
+  |> route(
+    method: Get,
+    path: "/unknown-encoding",
+    controller: api_controller.unknown_encoding,
+    middleware: [],
+  )
+  |> route(
+    method: Get,
+    path: "/corrupted-gzip",
+    controller: api_controller.corrupted_gzip,
+    middleware: [],
+  )
+  |> route(
+    method: Get,
+    path: "/echo-accept-encoding",
+    controller: api_controller.echo_accept_encoding,
+    middleware: [],
+  )
   // Streaming endpoints
   |> route(
     method: Get,
@@ -163,6 +200,25 @@ pub fn create_router() -> Router(EmptyContext, EmptyServices) {
     method: Get,
     path: "/stream/binary",
     controller: stream_controller.stream_binary,
+    middleware: [],
+  )
+  // Compressed streaming endpoints
+  |> route(
+    method: Get,
+    path: "/stream/gzip",
+    controller: stream_controller.stream_gzip,
+    middleware: [],
+  )
+  |> route(
+    method: Get,
+    path: "/stream/deflate",
+    controller: stream_controller.stream_deflate,
+    middleware: [],
+  )
+  |> route(
+    method: Get,
+    path: "/stream/unknown-encoding",
+    controller: stream_controller.stream_unknown_encoding,
     middleware: [],
   )
 }


### PR DESCRIPTION
## Summary

- **Streaming crash fix** — streaming requests no longer crash, hang, or silently time out when the upstream returns a complete HTTP error response (401, 403, 429, 500) instead of starting a stream
- **Transparent gzip/deflate compression** — the client automatically advertises `Accept-Encoding: gzip, deflate` and decompresses responses across all three execution modes with no API changes
- **Graceful handling of edge cases** — corrupted compressed data falls back to raw passthrough; unknown encodings pass through with a warning

## Changes

- 11 files changed, 1,591 insertions, 68 deletions
- 34 new tests (10 regression + 24 compression permutation matrix), 168 total
- Version bumped from 5.0.0 to 5.1.0

See [release notes](https://github.com/TrustBound/dream/blob/develop/modules/http_client/releases/release-5.1.0.md) for full details.