### PR TITLE
Prevent stream errors from being silently swallowed when servers misbehave

### DIFF
--- a/modules/http_client/CHANGELOG.md
+++ b/modules/http_client/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to `dream_http_client` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.1.1 - 2026-03-01
+
+### Fixed
+
+- **Stream error reasons are now always decodable as Gleam strings.** Previously,
+  transport-level errors from Erlang's `httpc` (e.g., `socket_closed_remotely`,
+  `{failed_connect, ...}`) were passed through as raw Erlang atoms/tuples in the
+  pull-based streaming path (`stream_yielder`), causing `d.string` decode failures
+  and hiding the real error behind "Unknown stream error". Additionally,
+  `format_error` could produce non-UTF-8 binaries (Latin-1 from `io_lib:format`),
+  which Gleam's string decoder rejected with `DecodeError("String", "String", [])`.
+- **All error formatting functions now guarantee valid UTF-8 output.** Added
+  `ensure_utf8_binary/1` helper that validates UTF-8, falls back to Latin-1
+  reinterpretation for binaries, and uses `~w` (pure ASCII) as a last resort.
+  Updated `format_error`, `format_complete_response_error`, `format_exit_reason`,
+  `to_binary`, and `ref_to_string` to use it.
+- **Pull-based streaming path now formats error reasons.** `stream_owner_wait`
+  and `stream_owner_next_message` now call `format_error(Reason)` on httpc error
+  reasons instead of passing raw Erlang terms through to the Gleam decoder.
+- **Gleam-side decoders have robust fallbacks.** Both `decode_error_reason` in
+  `client.gleam` and `receive_next` in `internal.gleam` now use a three-tier
+  fallback: try `d.string`, try `d.bit_array` with UTF-8 conversion, fall back
+  to `string.inspect`. Error reasons are never silently swallowed.
+- **9 new tests** covering transport-level errors (connection refused, connection
+  drop mid-stream), non-UTF-8 response bodies, and error string quality across
+  all three execution modes (`send`, `start_stream`, `stream_yielder`).
+
 ## 5.1.0 - 2026-02-28
 
 ### Added

--- a/modules/http_client/gleam.toml
+++ b/modules/http_client/gleam.toml
@@ -1,5 +1,5 @@
 name = "dream_http_client"
-version = "5.1.0"
+version = "5.1.1"
 description = "Type-safe HTTP client for Gleam with streaming support"
 licences = ["MIT"]
 repository = { type = "github", user = "TrustBound", repo = "dream" }

--- a/modules/http_client/releases/release-5.1.1.md
+++ b/modules/http_client/releases/release-5.1.1.md
@@ -1,0 +1,92 @@
+# dream_http_client v5.1.1
+
+**Release Date:** March 1, 2026
+
+This patch release fixes a bug where stream error reasons from Erlang's `httpc`
+could not be decoded as Gleam strings, causing error details to be silently lost
+or replaced with generic messages like "Unknown stream error".
+
+No API changes -- this is a fully transparent bug fix.
+
+---
+
+## Bug Fix: Stream error reason decoding
+
+### The problem
+
+Transport-level errors from `httpc` (connection refused, socket closed, DNS
+failure, etc.) produce raw Erlang atoms or tuples as error reasons. These were
+handled differently depending on the streaming path:
+
+- **Pull-based (`stream_yielder`)**: Raw Erlang terms were passed through
+  without formatting. `d.string` failed, and the error was silently replaced
+  with "Unknown stream error".
+- **Message-based (`start_stream`)**: `format_error` used
+  `iolist_to_binary(io_lib:format("~p", [Reason]))` which can produce
+  non-UTF-8 binary (Latin-1 bytes). Gleam's `d.string` validates UTF-8, so it
+  rejected the binary with `DecodeError("String", "String", [])`.
+
+In both cases, the actual error information (e.g., `econnrefused`,
+`socket_closed_remotely`) was lost.
+
+### Why previous tests didn't catch it
+
+All streaming tests hit the mock server, which always returns valid HTTP
+responses. Even the "error" tests (401, 500) produce the **complete HTTP
+response** message path, where `format_complete_response_error` outputs pure
+ASCII. The bug only fires on the **transport error** path
+(`{http, {Ref, {error, Reason}}}`) -- connection failures, socket drops, DNS
+errors -- which no mock server endpoint triggered.
+
+### The fix
+
+**Erlang side (belt):**
+
+- Added `ensure_utf8_binary/1` helper that validates UTF-8, falls back to
+  Latin-1 reinterpretation, then to `~w` (pure ASCII) as a last resort
+- Updated all 5 error formatting functions to use it: `format_error`,
+  `format_complete_response_error`, `format_exit_reason`, `to_binary`,
+  `ref_to_string`
+- Fixed `stream_owner_wait` and `stream_owner_next_message` to call
+  `format_error(Reason)` on raw httpc error reasons instead of passing
+  atoms/tuples through
+
+**Gleam side (suspenders):**
+
+- `decode_error_reason` in `client.gleam` now uses a three-tier fallback:
+  try `d.string` -> try `d.bit_array` with `to_string` -> fall back to
+  `string.inspect`
+- `receive_next` in `internal.gleam` uses the same three-tier fallback
+
+**New tests (9 tests, 177 total):**
+
+| Error type | send | start_stream | stream_yielder |
+|---|---|---|---|
+| Connection refused | test | test | test |
+| Connection drop mid-stream | -- | test | test |
+| Non-UTF-8 body in HTTP error | test | test | test |
+| Error string quality | -- | test | -- |
+
+**New mock server endpoints:**
+
+- `GET /stream/drop` -- sends 2 chunks then crashes to close the TCP socket
+  (triggers `socket_closed_remotely`)
+- `GET /non-utf8-error` -- returns HTTP 400 with a body containing invalid
+  UTF-8 bytes (0xC0, 0xC1, 0xFE, 0xFF)
+
+---
+
+## Files changed
+
+- `modules/http_client/src/dream_http_client/dream_httpc_shim.erl` -- added
+  `ensure_utf8_binary/1`, updated error formatting, fixed raw reason passthrough
+- `modules/http_client/src/dream_http_client/client.gleam` -- three-tier
+  fallback in `decode_error_reason`
+- `modules/http_client/src/dream_http_client/internal.gleam` -- three-tier
+  fallback in `receive_next`
+- `modules/http_client/test/stream_error_decode_test.gleam` -- 9 new tests
+- `modules/mock_server/src/dream_mock_server/controllers/api_controller.gleam`
+  -- added `/non-utf8-error` endpoint
+- `modules/mock_server/src/dream_mock_server/controllers/stream_controller.gleam`
+  -- added `/stream/drop` endpoint
+- `modules/mock_server/src/dream_mock_server/router.gleam` -- added routes

--- a/modules/http_client/src/dream_http_client/client.gleam
+++ b/modules/http_client/src/dream_http_client/client.gleam
@@ -2055,13 +2055,15 @@ fn decode_error_reason(
 ) -> StreamMessage {
   case d.run(reason_dyn, d.string) {
     Ok(reason) -> StreamError(req_id, reason)
-    Error(decode_error) -> {
-      let error_msg =
-        "Stream error (failed to decode error string: "
-        <> string.inspect(decode_error)
-        <> ")"
-      StreamError(req_id, error_msg)
-    }
+    Error(_) ->
+      case d.run(reason_dyn, d.bit_array) {
+        Ok(bytes) ->
+          case bit_array.to_string(bytes) {
+            Ok(s) -> StreamError(req_id, s)
+            Error(_) -> StreamError(req_id, string.inspect(reason_dyn))
+          }
+        Error(_) -> StreamError(req_id, string.inspect(reason_dyn))
+      }
   }
 }
 

--- a/modules/http_client/src/dream_http_client/dream_httpc_shim.erl
+++ b/modules/http_client/src/dream_http_client/dream_httpc_shim.erl
@@ -183,7 +183,7 @@ stream_owner_wait(RequestId, Buffer, StartHeaders, StartWaiters, ZlibCtx) ->
                               undefined);
         {http, {RequestId, {error, Reason}}} ->
             cleanup_zlib(ZlibCtx),
-            stream_owner_wait(RequestId, Buffer ++ [{error, Reason}], StartHeaders, StartWaiters, undefined);
+            stream_owner_wait(RequestId, Buffer ++ [{error, format_error(Reason)}], StartHeaders, StartWaiters, undefined);
         {http, {RequestId, {{_HttpVersion, StatusCode, ReasonPhrase}, _Headers, Body}}} ->
             cleanup_zlib(ZlibCtx),
             ErrorMsg = format_complete_response_error(StatusCode, ReasonPhrase, Body),
@@ -274,7 +274,7 @@ stream_owner_next_message(RequestId, ZlibCtx) ->
             {{finished, normalize_headers(Headers)}, undefined};
         {http, {RequestId, {error, Reason}}} ->
             cleanup_zlib(ZlibCtx),
-            {{error, Reason}, undefined};
+            {{error, format_error(Reason)}, undefined};
         {http, {RequestId, {{_HttpVersion, StatusCode, ReasonPhrase}, _Headers, Body}}} ->
             cleanup_zlib(ZlibCtx),
             {{error, format_complete_response_error(StatusCode, ReasonPhrase, Body)}, undefined};
@@ -789,7 +789,27 @@ to_binary(Bin) when is_binary(Bin) ->
 to_binary(List) when is_list(List) ->
     unicode:characters_to_binary(List);
 to_binary(Other) ->
-    iolist_to_binary(io_lib:format("~p", [Other])).
+    ensure_utf8_binary(io_lib:format("~p", [Other])).
+
+%% Guarantee a valid UTF-8 binary from any input.
+%% Handles binaries (validates UTF-8, falls back to Latin-1 reinterpretation),
+%% charlists from io_lib:format (unicode codepoints), and arbitrary terms.
+ensure_utf8_binary(Bin) when is_binary(Bin) ->
+    case unicode:characters_to_binary(Bin, utf8, utf8) of
+        Result when is_binary(Result) -> Result;
+        _ ->
+            case unicode:characters_to_binary(Bin, latin1, utf8) of
+                Result2 when is_binary(Result2) -> Result2;
+                _ -> iolist_to_binary(io_lib:format("~w", [Bin]))
+            end
+    end;
+ensure_utf8_binary(List) when is_list(List) ->
+    case unicode:characters_to_binary(List) of
+        Result when is_binary(Result) -> Result;
+        _ -> iolist_to_binary(io_lib:format("~w", [List]))
+    end;
+ensure_utf8_binary(Other) ->
+    iolist_to_binary(io_lib:format("~w", [Other])).
 
 %% @doc Make a synchronous (blocking) HTTP request
 %%
@@ -852,20 +872,18 @@ request_sync(Method, Url, Headers, Body, TimeoutMs) ->
     end.
 
 format_error(Reason) ->
-    iolist_to_binary(io_lib:format("~p", [Reason])).
+    ensure_utf8_binary(io_lib:format("~p", [Reason])).
 
 %% Format error for a complete (non-streaming) HTTP response from httpc.
 %% httpc sends this instead of stream_start/stream/stream_end when the upstream
 %% returns a non-streaming response (typically 4xx/5xx errors).
 format_complete_response_error(StatusCode, ReasonPhrase, Body) ->
-    iolist_to_binary([
-        <<"HTTP ">>,
-        integer_to_binary(StatusCode),
-        <<" ">>,
-        to_binary(ReasonPhrase),
-        <<": ">>,
-        to_binary(Body)
-    ]).
+    <<(<<"HTTP ">>)/binary,
+      (integer_to_binary(StatusCode))/binary,
+      (<<" ">>)/binary,
+      (ensure_utf8_binary(ReasonPhrase))/binary,
+      (<<": ">>)/binary,
+      (ensure_utf8_binary(Body))/binary>>.
 
 %% Format exit reason from owner process death
 %%
@@ -879,7 +897,7 @@ format_exit_reason(normal) ->
     <<"Stream process exited normally">>;
 format_exit_reason(Reason) ->
     %% Some other exit reason - format it for debugging
-    iolist_to_binary(io_lib:format("Stream process died: ~p", [Reason])).
+    ensure_utf8_binary(io_lib:format("Stream process died: ~p", [Reason])).
 
 %% =============================================================================
 %% ETS Functions for Stream Recorder State Management
@@ -1086,7 +1104,7 @@ ensure_ref_mapping_table() ->
 %% Convert httpc ref to unique string ID
 %% Uses the ref's string representation which is guaranteed unique
 ref_to_string(Ref) ->
-    list_to_binary(io_lib:format("~p", [Ref])).
+    ensure_utf8_binary(io_lib:format("~p", [Ref])).
 
 %% Store bidirectional mapping: string <-> ref
 store_ref_mapping(StringId, HttpcRef) ->

--- a/modules/http_client/src/dream_http_client/internal.gleam
+++ b/modules/http_client/src/dream_http_client/internal.gleam
@@ -8,6 +8,7 @@
 //// This is an internal module. Use `dream_http_client/client`,
 //// `dream_http_client/recorder`, and `dream_http_client/matching` instead.
 
+import gleam/bit_array
 import gleam/dynamic/decode as d
 import gleam/erlang/atom
 import gleam/erlang/process
@@ -167,9 +168,18 @@ pub fn receive_next(
     }
     "finished" -> Ok(option.None)
     "error" -> {
-      let reason =
-        d.run(resp, d.at([1], d.string))
-        |> result.unwrap("Unknown stream error")
+      let reason = case d.run(resp, d.at([1], d.string)) {
+        Ok(s) -> s
+        Error(_) ->
+          case d.run(resp, d.at([1], d.bit_array)) {
+            Ok(bytes) ->
+              case bit_array.to_string(bytes) {
+                Ok(s) -> s
+                Error(_) -> string.inspect(resp)
+              }
+            Error(_) -> string.inspect(resp)
+          }
+      }
       Error(reason)
     }
     _ -> Error("Unexpected stream message tag: " <> tag)

--- a/modules/http_client/test/stream_error_decode_test.gleam
+++ b/modules/http_client/test/stream_error_decode_test.gleam
@@ -1,0 +1,265 @@
+//// Tests for stream error reason decoding robustness
+////
+//// Verifies that the HTTP client can decode error reasons from Erlang's httpc
+//// regardless of the error format: transport-level errors (atoms/tuples from
+//// httpc), non-UTF-8 response bodies, and connection failures. Both the
+//// message-based (start_stream) and pull-based (stream_yielder) paths are
+//// tested.
+////
+//// These tests close the gap left by stream_non_streaming_response_test.gleam,
+//// which only covered HTTP error responses (complete response messages). The
+//// tests here cover the {error, Reason} message path from httpc, which fires
+//// on transport-level failures like connection refused and socket drops.
+
+import dream_http_client/client
+import dream_http_client_test
+import gleam/erlang/process
+import gleam/http
+import gleam/io
+import gleam/string
+import gleam/yielder
+import gleeunit/should
+
+fn mock_request(path: String) -> client.ClientRequest {
+  client.new()
+  |> client.method(http.Get)
+  |> client.scheme(http.Http)
+  |> client.host("localhost")
+  |> client.port(dream_http_client_test.get_test_port())
+  |> client.path(path)
+}
+
+fn dead_port_request() -> client.ClientRequest {
+  client.new()
+  |> client.method(http.Get)
+  |> client.scheme(http.Http)
+  |> client.host("localhost")
+  |> client.port(1)
+  |> client.path("/anything")
+  |> client.timeout(3000)
+}
+
+// ============================================================================
+// Connection refused tests (httpc {error, Reason} path with atom/tuple reason)
+// ============================================================================
+
+/// start_stream to a closed port must fire on_stream_error with a readable string
+pub fn start_stream_connection_refused_surfaces_error_test() {
+  let error_subject = process.new_subject()
+
+  let request =
+    dead_port_request()
+    |> client.on_stream_error(fn(reason) { process.send(error_subject, reason) })
+
+  let _result = client.start_stream(request)
+
+  case process.receive(error_subject, 10_000) {
+    Ok(reason) -> {
+      { string.length(reason) > 0 } |> should.be_true()
+      io.println(
+        "start_stream connection refused error: " <> string.slice(reason, 0, 80),
+      )
+    }
+    Error(Nil) -> {
+      io.println(
+        "on_stream_error was never called for connection refused (start_stream)",
+      )
+      should.fail()
+    }
+  }
+}
+
+/// stream_yielder to a closed port must yield Error with a readable string
+pub fn stream_yielder_connection_refused_surfaces_error_test() {
+  let req = dead_port_request()
+  let results = client.stream_yielder(req) |> yielder.take(1) |> yielder.to_list
+
+  { results != [] } |> should.be_true()
+
+  let assert [first, ..] = results
+  case first {
+    Error(reason) -> {
+      { string.length(reason) > 0 } |> should.be_true()
+      io.println(
+        "stream_yielder connection refused error: "
+        <> string.slice(reason, 0, 80),
+      )
+    }
+    Ok(_) -> {
+      io.println("Expected Error for connection refused, got Ok")
+      should.fail()
+    }
+  }
+}
+
+/// send() to a closed port must return RequestError with a readable string
+pub fn send_connection_refused_surfaces_error_test() {
+  let req = dead_port_request()
+  case client.send(req) {
+    Error(client.RequestError(message: reason)) -> {
+      { string.length(reason) > 0 } |> should.be_true()
+      io.println(
+        "send() connection refused error: " <> string.slice(reason, 0, 80),
+      )
+    }
+    Error(client.ResponseError(response: _)) -> {
+      io.println("Expected RequestError, got ResponseError")
+      should.fail()
+    }
+    Ok(_) -> {
+      io.println("Expected Error for connection refused, got Ok")
+      should.fail()
+    }
+  }
+}
+
+// ============================================================================
+// Connection drop mid-stream tests (socket_closed_remotely)
+// ============================================================================
+
+/// start_stream to /stream/drop must fire on_stream_error, not crash
+pub fn start_stream_connection_drop_surfaces_error_test() {
+  let error_subject = process.new_subject()
+  let chunk_subject = process.new_subject()
+
+  let request =
+    mock_request("/stream/drop")
+    |> client.on_stream_chunk(fn(data) { process.send(chunk_subject, data) })
+    |> client.on_stream_error(fn(reason) { process.send(error_subject, reason) })
+
+  let assert Ok(_handle) = client.start_stream(request)
+
+  case process.receive(error_subject, 10_000) {
+    Ok(reason) -> {
+      { string.length(reason) > 0 } |> should.be_true()
+      io.println("start_stream drop error: " <> string.slice(reason, 0, 80))
+    }
+    Error(Nil) -> {
+      io.println(
+        "on_stream_error was never called for connection drop (start_stream)",
+      )
+      should.fail()
+    }
+  }
+}
+
+/// stream_yielder to /stream/drop must eventually yield Error
+pub fn stream_yielder_connection_drop_surfaces_error_test() {
+  let req = mock_request("/stream/drop")
+  let results =
+    client.stream_yielder(req) |> yielder.take(10) |> yielder.to_list
+
+  let has_error =
+    results
+    |> yielder.from_list
+    |> yielder.any(fn(r) {
+      case r {
+        Error(_) -> True
+        Ok(_) -> False
+      }
+    })
+
+  has_error |> should.be_true()
+}
+
+// ============================================================================
+// Non-UTF-8 response body tests
+// ============================================================================
+
+/// start_stream to /non-utf8-error must fire on_stream_error with decodable reason
+pub fn start_stream_non_utf8_error_body_surfaces_error_test() {
+  let error_subject = process.new_subject()
+
+  let request =
+    mock_request("/non-utf8-error")
+    |> client.on_stream_error(fn(reason) { process.send(error_subject, reason) })
+
+  let assert Ok(_handle) = client.start_stream(request)
+
+  case process.receive(error_subject, 5000) {
+    Ok(reason) -> {
+      { string.length(reason) > 0 } |> should.be_true()
+      string.contains(reason, "400") |> should.be_true()
+      io.println(
+        "start_stream non-UTF-8 error: " <> string.slice(reason, 0, 80),
+      )
+    }
+    Error(Nil) -> {
+      io.println(
+        "on_stream_error was never called for non-UTF-8 error body (start_stream)",
+      )
+      should.fail()
+    }
+  }
+}
+
+/// stream_yielder to /non-utf8-error must yield Error with readable reason
+pub fn stream_yielder_non_utf8_error_body_surfaces_error_test() {
+  let req = mock_request("/non-utf8-error")
+  let results = client.stream_yielder(req) |> yielder.take(1) |> yielder.to_list
+
+  { results != [] } |> should.be_true()
+
+  let assert [first, ..] = results
+  case first {
+    Error(reason) -> {
+      { string.length(reason) > 0 } |> should.be_true()
+      string.contains(reason, "400") |> should.be_true()
+      io.println(
+        "stream_yielder non-UTF-8 error: " <> string.slice(reason, 0, 80),
+      )
+    }
+    Ok(_) -> {
+      io.println("Expected Error for non-UTF-8 error body, got Ok")
+      should.fail()
+    }
+  }
+}
+
+/// send() to /non-utf8-error must return an Error (not crash).
+/// Since HttpResponse.body is typed as String, non-UTF-8 bytes cause a
+/// RequestError("Failed to convert response to string") which is correct —
+/// the body can't be represented as a Gleam String.
+pub fn send_non_utf8_error_body_surfaces_error_test() {
+  let req = mock_request("/non-utf8-error")
+  case client.send(req) {
+    Error(client.RequestError(message: msg)) -> {
+      { string.length(msg) > 0 } |> should.be_true()
+      io.println("send() non-UTF-8 body error (expected): " <> msg)
+    }
+    Error(client.ResponseError(response: _resp)) -> {
+      // Also acceptable if the body was lossy-decoded
+      Nil
+    }
+    Ok(_) -> {
+      io.println("Expected Error for non-UTF-8 error body, got Ok")
+      should.fail()
+    }
+  }
+}
+
+// ============================================================================
+// Error string quality tests
+// ============================================================================
+
+/// Connection refused errors must contain useful diagnostic info, not just
+/// "Unknown stream error" or a raw Erlang term dump
+pub fn connection_refused_error_is_not_unknown_test() {
+  let error_subject = process.new_subject()
+
+  let request =
+    dead_port_request()
+    |> client.on_stream_error(fn(reason) { process.send(error_subject, reason) })
+
+  let _result = client.start_stream(request)
+
+  case process.receive(error_subject, 10_000) {
+    Ok(reason) -> {
+      string.contains(reason, "Unknown stream error") |> should.be_false()
+    }
+    Error(Nil) -> {
+      io.println("on_stream_error was never called")
+      should.fail()
+    }
+  }
+}

--- a/modules/mock_server/src/dream_mock_server/controllers/api_controller.gleam
+++ b/modules/mock_server/src/dream_mock_server/controllers/api_controller.gleam
@@ -229,6 +229,27 @@ pub fn corrupted_gzip(
   )
 }
 
+/// GET /non-utf8-error - Returns HTTP 400 with a body containing non-UTF-8 bytes
+///
+/// The body is "Error: " followed by bytes 0xC0, 0xC1, 0xFE, 0xFF which are
+/// invalid in UTF-8 encoding. Used to test that the HTTP client can handle
+/// error responses whose bodies are not valid UTF-8.
+pub fn non_utf8_error(
+  _request: Request,
+  _context: EmptyContext,
+  _services: EmptyServices,
+) -> Response {
+  // "Error: " as ASCII + invalid UTF-8 bytes (0xC0, 0xC1, 0xFE, 0xFF)
+  let body = <<69, 114, 114, 111, 114, 58, 32, 192, 193, 254, 255>>
+  response.Response(
+    status: status.bad_request,
+    body: response.Bytes(body),
+    headers: [Header("Content-Type", "text/plain")],
+    cookies: [],
+    content_type: option.Some("text/plain"),
+  )
+}
+
 /// GET /echo-accept-encoding - Echoes the request's Accept-Encoding header
 pub fn echo_accept_encoding(
   request: Request,

--- a/modules/mock_server/src/dream_mock_server/controllers/stream_controller.gleam
+++ b/modules/mock_server/src/dream_mock_server/controllers/stream_controller.gleam
@@ -123,6 +123,33 @@ fn create_error_chunk(n: Int) -> BitArray {
   bit_array.from_string(line)
 }
 
+/// Drop streaming - sends 2 chunks then crashes to close the socket
+///
+/// Simulates a server that drops the connection mid-stream. The yielder
+/// sends 2 valid chunks then panics, which kills the handler process and
+/// abruptly closes the TCP socket. This triggers httpc's {error, Reason}
+/// path (e.g., socket_closed_remotely) instead of the normal stream_end path.
+pub fn stream_drop(
+  _request: Request,
+  _context: EmptyContext,
+  _services: EmptyServices,
+) -> Response {
+  let stream =
+    yielder.range(1, 5)
+    |> yielder.map(fn(n) {
+      case n > 2 {
+        True -> panic as "intentional crash to drop connection"
+        False -> {
+          process.sleep(50)
+          let line = "Drop chunk " <> int.to_string(n) <> "\n"
+          bit_array.from_string(line)
+        }
+      }
+    })
+
+  stream_response(status.ok, stream, "text/plain")
+}
+
 /// Huge streaming - 100 chunks for memory/performance testing
 ///
 /// Demonstrates large response streaming.

--- a/modules/mock_server/src/dream_mock_server/router.gleam
+++ b/modules/mock_server/src/dream_mock_server/router.gleam
@@ -159,6 +159,12 @@ pub fn create_router() -> Router(EmptyContext, EmptyServices) {
     controller: api_controller.echo_accept_encoding,
     middleware: [],
   )
+  |> route(
+    method: Get,
+    path: "/non-utf8-error",
+    controller: api_controller.non_utf8_error,
+    middleware: [],
+  )
   // Streaming endpoints
   |> route(
     method: Get,
@@ -188,6 +194,12 @@ pub fn create_router() -> Router(EmptyContext, EmptyServices) {
     method: Get,
     path: "/stream/huge",
     controller: stream_controller.stream_huge,
+    middleware: [],
+  )
+  |> route(
+    method: Get,
+    path: "/stream/drop",
+    controller: stream_controller.stream_drop,
     middleware: [],
   )
   |> route(


### PR DESCRIPTION
## Summary

When making streaming HTTP requests, transport-level failures (connection refused, socket dropped mid-stream, DNS errors) caused the HTTP client to lose the actual error details and replace them with unhelpful generic messages like "Unknown stream error". This meant developers couldn't tell *why* their streaming request failed -- the real reason was silently discarded.

This fix ensures that no matter what the server sends back -- malformed data, non-UTF-8 bytes, raw Erlang atoms, or abrupt disconnects -- the error reason always surfaces as a readable, meaningful string.

## Why

- Streaming errors from Erlang's `httpc` arrive as raw atoms or tuples (e.g., `socket_closed_remotely`, `{failed_connect, ...}`), not strings. The pull-based streaming path (`stream_yielder`) passed these through without formatting, so Gleam's string decoder failed and the error was replaced with "Unknown stream error".
- The message-based streaming path (`start_stream`) did format errors, but `io_lib:format` can produce Latin-1 encoded bytes. Gleam enforces strict UTF-8, so it rejected these with a cryptic `DecodeError("String", "String", [])`, again hiding the real error.
- Previous tests only hit the mock server which always returns well-formed HTTP responses. Transport-level failures (connection refused, socket drops) were never exercised, so this gap went undetected.

## What

- **Erlang layer**: Added `ensure_utf8_binary/1` that guarantees valid UTF-8 output from any Erlang term. Updated all 5 error formatting functions to use it. Fixed the pull-based path to format raw error reasons before passing them to Gleam.
- **Gleam layer**: Added three-tier fallback decoders in both `decode_error_reason` and `receive_next` -- try string, try bit_array with UTF-8 conversion, fall back to `string.inspect`. Error reasons can never be silently lost.
- **Mock server**: Added `/stream/drop` (sends chunks then crashes to simulate connection drop) and `/non-utf8-error` (returns HTTP 400 with invalid UTF-8 bytes in the body).
- **Tests**: 9 new tests covering connection refused, mid-stream connection drops, and non-UTF-8 error bodies across all three execution modes (`send`, `start_stream`, `stream_yielder`). All 177 tests pass.
- **Version**: Bumped to 5.1.1 with changelog and release notes.

## How

The fix uses a "belt and suspenders" approach -- errors are sanitized to valid UTF-8 strings on the Erlang side *and* decoded with robust fallbacks on the Gleam side. This dual-layer defense ensures that even if a future Erlang OTP update changes the error format, the client will still surface a useful error message rather than crashing or swallowing the details.

## Test plan

- [x] Connection refused errors surface meaningful messages across all streaming modes
- [x] Mid-stream connection drops are caught and reported correctly
- [x] Non-UTF-8 response bodies don't crash the client
- [x] Error strings contain useful information (not "Unknown stream error")
- [x] All 177 existing tests still pass (no regressions)