### PR TITLE
http_client: allow gleam_stdlib 1.x

### DIFF
--- a/modules/http_client/CHANGELOG.md
+++ b/modules/http_client/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `dream_http_client` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- **`gleam_stdlib` requirement widened to `>= 0.60.0 and < 2.0.0`.** The
+  previous `< 1.0.0` cap made the package unresolvable in projects that use
+  `gleam_stdlib` 1.x. No code changes were needed: the package compiles
+  cleanly against `gleam_stdlib` 1.0.5, and the test suite passes at the
+  locked version.
+
 ## 5.1.3 - 2026-03-17
 
 ### Fixed

--- a/modules/http_client/gleam.toml
+++ b/modules/http_client/gleam.toml
@@ -9,7 +9,7 @@ links = [
 ]
 
 [dependencies]
-gleam_stdlib = ">= 0.60.0 and < 1.0.0"
+gleam_stdlib = ">= 0.60.0 and < 2.0.0"
 gleam_erlang = ">= 1.1.0 and < 2.0.0"
 gleam_http = ">= 4.3.0 and < 5.0.0"
 gleam_json = ">= 3.0.1 and < 4.0.0"

--- a/modules/http_client/manifest.toml
+++ b/modules/http_client/manifest.toml
@@ -2,8 +2,8 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "dream", version = "2.3.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "gleam_yielder", "marceau", "mist", "simplifile"], source = "local", path = "../.." },
-  { name = "dream_mock_server", version = "1.0.0", build_tools = ["gleam"], requirements = ["dream", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_yielder"], source = "local", path = "../mock_server" },
+  { name = "dream", version = "2.4.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_time", "gleam_yielder", "marceau", "mist", "simplifile"], source = "local", path = "../.." },
+  { name = "dream_mock_server", version = "1.1.1", build_tools = ["gleam"], requirements = ["dream", "gleam_erlang", "gleam_http", "gleam_json", "gleam_otp", "gleam_stdlib", "gleam_yielder"], source = "local", path = "../mock_server" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
@@ -35,7 +35,7 @@ gleam_erlang = { version = ">= 1.1.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.3.0 and < 5.0.0" }
 gleam_json = { version = ">= 3.0.1 and < 4.0.0" }
 gleam_otp = { version = ">= 1.2.0 and < 2.0.0" }
-gleam_stdlib = { version = ">= 0.60.0 and < 1.0.0" }
+gleam_stdlib = { version = ">= 0.60.0 and < 2.0.0" }
 gleam_yielder = { version = ">= 1.1.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 mockth = { git = "https://github.com/bondiano/mockth.git", ref = "master" }


### PR DESCRIPTION
## Description

`dream_http_client` requires `gleam_stdlib >= 0.60.0 and < 1.0.0`. Now that `gleam_stdlib` 1.x is out, that cap makes the package unresolvable in any project on stdlib 1.x as the resolver can't co-resolve the two, so downstream users are stuck forking or pinning old stdlib. This PR widens the requirement to `>= 0.60.0 and < 2.0.0`.

No code changes were needed. The package compiles cleanly against `gleam_stdlib` 1.0.5 as-is, and we run a fork of it in production against stdlib 1.0.x with our full test suite green (including recording/playback and streaming).

The commit also syncs two stale path-dependency versions in the module's `manifest.toml` (`dream` 2.3.1 → 2.4.1, `dream_mock_server` 1.0.0 → 1.1.1). As committed, `gleam` refuses to build the module because the lock disagrees with the `== 1.1.1` requirement.

## Related Issue

N/A

## Type of Change

- [x] 🔧 Build/CI changes

## Changes Made

- Widen `gleam_stdlib` to `>= 0.60.0 and < 2.0.0` in `modules/http_client/gleam.toml` and its manifest
- Sync stale `dream` / `dream_mock_server` path-dep versions in `modules/http_client/manifest.toml`
- CHANGELOG entry under Unreleased

## Testing

- [x] All tests pass (`gleam test` in `modules/http_client`: 192 passed at the locked stdlib 0.67.1)
- [x] Code formatted with `gleam format`
- [x] No compiler warnings
- Additionally verified the package compiles standalone against `gleam_stdlib` 1.0.5, and a downstream consumer's full suite passes against it

## Documentation

- [x] CHANGELOG updated (for maintainer review)

## Breaking Changes

N/A — the constraint only widens; the existing lock resolution is unchanged.

## Additional Context

N/A